### PR TITLE
Don't set noauto on root filesystem in fstab

### DIFF
--- a/buildroot/board/raspberrypi3/overlay/etc/fstab
+++ b/buildroot/board/raspberrypi3/overlay/etc/fstab
@@ -1,4 +1,4 @@
-/dev/root / ext2 rw,noauto 0 1
+/dev/root / ext2 rw 0 1
 proc /proc proc defaults 0 0
 devpts /dev/pts devpts defaults,gid=5,mode=620,ptmxmode=0666 0 0
 tmpfs /dev/shm tmpfs mode=0777 0 0

--- a/buildroot/board/raspberrypi3/overlay/etc/fstab
+++ b/buildroot/board/raspberrypi3/overlay/etc/fstab
@@ -1,9 +1,8 @@
-/dev/root	/		ext2	rw,noauto	0	1
-proc		/proc		proc	defaults	0	0
-devpts		/dev/pts	devpts	defaults,gid=5,mode=620,ptmxmode=0666	0	0
-tmpfs		/dev/shm	tmpfs	mode=0777	0	0
-tmpfs		/tmp		tmpfs	mode=1777	0	0
-tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
-sysfs		/sys		sysfs	defaults	0	0
-/dev/mmcblk0p1  /boot		vfat	defaults	0	0
-
+/dev/root / ext2 rw,noauto 0 1
+proc /proc proc defaults 0 0
+devpts /dev/pts devpts defaults,gid=5,mode=620,ptmxmode=0666 0 0
+tmpfs /dev/shm tmpfs mode=0777 0 0
+tmpfs /tmp tmpfs mode=1777 0 0
+tmpfs /run tmpfs mode=0755,nosuid,nodev 0 0
+sysfs /sys sysfs defaults 0 0
+/dev/mmcblk0p1 /boot vfat defaults 0 0


### PR DESCRIPTION
It produces these warning messages:

```
systemd-fstab-generator: Ignoring "noauto" for root device
```