### PR TITLE
Updated setupdev.md to include prepare-software

### DIFF
--- a/doc/setupdev.md
+++ b/doc/setupdev.md
@@ -16,6 +16,12 @@ ln -s buildroot-2019.08.1 buildroot
 Note that newer releases than buildroot 2019-08 won't work at the moment due to incompatibilities
 of the Python interpreter.
 
+## Install Prerequisites
+```
+cd hifiberry-os
+./prepare-software
+```
+
 ## Clone the HiFiBerryOS sources
 
 ```


### PR DESCRIPTION
Added note to setupdev.md to mention running ./prepare-software, as if this is missing the compile will fail due to a missing install of hifiberrydsp.