### PR TITLE
Update building.md to address 'known_hosts' error

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -65,7 +65,13 @@ Creates the image and update files for a specific Raspberry Pi hardware. Paramet
 ## update-pi
 
 Creates an image from the latest compile run and pushes it to the Raspberry Pi given as a command line parameter.
-To make sure this works, the version of Raspberry Pi must match the version that you compiles the image for. Also the updater expects that the Pi still uses the default password. YOu also need to have the sshpass tool installed. 
+To make sure this works, the version of Raspberry Pi must match the version that you compiled the image for. Also, the updater expects that the Pi is still using the default password, though you can override this.
+
+`./update-pi {VERSION} {HOST_IP} {PORT=22} {PASSWORD=hifiberry}`
+
+You will also need to have `sshpass` installed, make sure to add the host keys for each new Pi to your known hosts file before beginning an update, e.g.
+
+`ssh-keyscan raspberrypi-ip >> ~/.ssh/known_hosts`
 
 ## build-all
 


### PR DESCRIPTION
Calling ./update-pi will fail if that specific Pi has not been added to your known hosts file.
Added note to put the host into the known_hosts file before starting an update, as there is no option to add the host during the update process, and it fails instead.