### PR TITLE
Feature brutefir

### DIFF
--- a/buildroot/Config.in
+++ b/buildroot/Config.in
@@ -44,6 +44,7 @@ source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/snapcastmpris/Config.in"
 source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/webradio/Config.in"
 
 comment "Backend applications"
+source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/brutefir/Config.in"
 source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/dsptoolkit/Config.in"
 source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/dspprofiles/Config.in"
 source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/audiocontrol2/Config.in"
@@ -97,4 +98,3 @@ source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/python-youtube-dl/Config.in"
 
 comment "Test tools"
 source "$BR2_EXTERNAL_HIFIBERRY_PATH/package/hifiberry-test/Config.in"
-

--- a/buildroot/package/brutefir/Config.in
+++ b/buildroot/package/brutefir/Config.in
@@ -1,0 +1,9 @@
+# from https://github.com/badaix/snapos
+
+config BR2_PACKAGE_BRUTEFIR
+	bool "Brutefir"
+	help
+        brutefir
+    select BR2_PACKAGE_FFTW
+    select BR2_PACKAGE_FFTW_DOUBLE
+    select BR2_PACKAGE_FFTW_SINGLE

--- a/buildroot/package/brutefir/brutefir.mk
+++ b/buildroot/package/brutefir/brutefir.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BRUTEFIR_VERSION = 62c1c1a32ebd855ca742513aae74f24a74bf49d2
+BRUTEFIR_VERSION = 21f5a980371da9d3705cf87c2dc36252b343bfad
 BRUTEFIR_SITE = https://github.com/soundart/brutefir.git
 BRUTEFIR_SITE_METHOD = git
 BRUTEFIR_DEPENDENCIES =

--- a/buildroot/package/brutefir/brutefir.mk
+++ b/buildroot/package/brutefir/brutefir.mk
@@ -1,0 +1,22 @@
+################################################################################
+#
+# brutefir
+#
+################################################################################
+
+BRUTEFIR_VERSION = 62c1c1a32ebd855ca742513aae74f24a74bf49d2
+BRUTEFIR_SITE = https://github.com/soundart/brutefir.git
+BRUTEFIR_SITE_METHOD = git
+BRUTEFIR_DEPENDENCIES =
+BRUTEFIR_LICENSE = GPL-2.0
+BRUTEFIR_LICENSE_FILES = LICENSE
+
+
+define BRUTEFIR_INSTALL_EXTRA_FILES
+	$(INSTALL) -D -m 0644 $(BR2_EXTERNAL_HIFIBERRY_PATH)/package/brutefir/brutefir_mpd_config \
+		$(TARGET_DIR)/etc/brutefir_mpd_config
+endef
+
+BRUTEFIR_POST_INSTALL_TARGET_HOOKS += BRUTEFIR_INSTALL_EXTRA_FILES
+
+$(eval $(cmake-package))

--- a/buildroot/package/brutefir/brutefir_mpd_config
+++ b/buildroot/package/brutefir/brutefir_mpd_config
@@ -1,0 +1,75 @@
+float_bits: 32;             # internal floating point precision
+sampling_rate: 44100;       # sampling rate in Hz of audio interfaces
+filter_length: 65536;       # length of filters
+overflow_warnings: true;    # echo warnings to stderr if overflow occurs
+show_progress: true;        # echo filtering progress to stderr
+max_dither_table_size: 0;   # maximum size in bytes of precalculated dither
+allow_poll_mode: false;     # allow use of input poll mode
+modules_path: ".";          # extra path where to find BruteFIR modules
+monitor_rate: false;        # monitor sample rate
+powersave: false;           # pause filtering when input is zero
+lock_memory: true;          # try to lock memory if realtime prio is set
+sdf_length: -1;             # subsample filter half length in samples
+safety_limit: 20;           # if non-zero max dB in output before aborting
+convolver_config: "/var/run/brutefir_convolver"; # location of convolver config file
+
+
+#logic: "cli" { port: 3000; };
+
+input 0, 1 {
+        device: "file" { path: "/proc/self/fd/0"; };
+        sample: "S32_LE";
+        channels: 2;
+};
+
+#utput 0, 1 {
+#       device: "file" { path: "/dev/stdin"; };
+#       sample: "S32_LE";
+#       channels: 2;
+#;
+
+output 0, 1 {
+  device: "alsa"
+  {
+     device: "hw:0,0";
+  };
+  sample: "S32_LE";
+	channels: 2/0,1;    # number of open channels / which to use
+        delay: 0,0;         # delay in samples for each channel
+        maxdelay: -1;       # max delay for variable delays
+        subdelay: 0,0;      # subsample delay in 1/100th sample for each channel
+        mute: false,false;  # mute active on startup for each channel
+        dither: false;      # apply dither
+};
+
+filter 0 {
+	from_inputs: 0;
+	to_outputs: 0;
+	coeff: "equilizer";
+};
+
+filter 1 {
+	from_inputs: 1;
+	to_outputs: 1;
+	coeff: "equilizer";
+};
+
+logic:  "cli" { port: 3000; }, "eq"  {
+      debug_dump_filter: "/tmp/rendered-%d";
+		{
+			coeff: "equilizer";
+			# bands: "ISO octave";
+			bands: "ISO 1/3 octave";
+			#bands: 100, 200, 500;
+			#magnitude: 20/-3.2, 100/8.5;
+                        # magnitude: 31.5/0, 63/0, 125/0, 250/-4.5, 500/-9, 1000/-9, 2000/-9.5, 4000/-10, 8000/-4.5, 16000/0;
+			# magnitude: 31.5/-30, 63/0, 125/0, 250/-2.5, 500/-6, 1000/-6, 2000/-4.5, 4000/-3, 8000/-2.5, 16000/0;
+			magnitude: 20/0, 25/0, 31/0, 40/0, 50/0, 63/0, 80/0, 100/0, 125/0, 160/0, 200/0, 250/-2, 315/-3, 400/-4, 500/-4, 630/-4, 800/-4, 1000/-4, 1250/-4, 1600/-4, 2000/-4, 2500/-3, 3150/-2, 4000/0, 5000/0, 6300/0, 8000/0, 10000/0, 12500/0, 16000/0, 20000/0;
+			#phase: 20/0, 100/180;
+		};
+	};
+coeff "equilizer" {
+                filename: "dirac pulse";
+                shared_mem: true;
+                #blocks: 16;
+};

--- a/buildroot/package/brutefir/mpd.conf
+++ b/buildroot/package/brutefir/mpd.conf
@@ -1,0 +1,44 @@
+# cat /etc/mpd.conf
+#
+# Sample configuration file for mpd
+# This is a minimal configuration, see the manpage for more options
+#
+
+# Directory where the music is stored
+music_directory         "/library/music"
+
+# Directory where user-made playlists are stored (RW)
+playlist_directory      "/library/playlists"
+
+# Database file (RW)
+db_file                 "/library/mpd"
+
+# Log file (RW)
+log_file                "syslog"
+
+# Process ID file (RW)
+pid_file                "/var/run/mpd.pid"
+
+# State file (RW)
+#state_file              "/var/lib/mpd/state"
+
+# TCP socket binding
+bind_to_address         "any"
+
+
+audio_output {
+  type "pipe"
+  name "brutefir pipe"
+  command "brutefir -nodefault /etc/brutefir_mpd_config"
+  #command "aplay -f cd 2>/dev/null"
+  format "*:32:2"
+#  always_on "yes"
+}
+
+#audio_output {
+#        type            "alsa"
+#        name            "HiFiBerry"
+#        device          "default"
+#        mixer_control   "Digital"
+#        enabled         "yes"
+#}


### PR DESCRIPTION
Hi Daniel & Hifiberries,

this pull request adds the brutefir package.

- What is it good for?

From: https://torger.se/anders/brutefir.html

A few examples of applications where BruteFIR could be a central component:

    Digital crossover filters
    Room equalization
    Cross-talk cancellation
    Wavefield synthesis
    Auralization
    Ambiophonics
    Ambisonics 


- hifiberry usage

The idea is currently to add it as a output to mpd:
cat /etc/mpd.conf
```
...
audio_output {
  type "pipe"
  name "brutefir pipe"
  command "brutefir -nodefault /etc/brutefir_mpd_config"
  format "*:32:2"
  # always_on "yes"
}
...


```

- I use it currently as an equalizer:
cat /etc/brutefir_mpd_config
```
...
magnitude: 20/0, 25/0, 31/0, 40/0, 50/0, 63/0, 80/0, 100/0, 125/0, 160/0, 200/0, 250/-2, 315/-3, 400/-4, 500/-4, 630/-4, 800/-4, 1000/-4, 1250/-4, 1600/-4, 2000/-4, 2500/-3, 3150/-2, 4000/0, 5000/0, 6300/0, 8000/0, 10000/0, 12500/0, 16000/0, 20000/0;
...
```

The coeffizients are changable by sending commands to port 3000. See https://torger.se/anders/brutefir.html "Run-time equalizer" 

Comments welcome. 

kind regards
   Frank

