### PR TITLE
Update Hifiberry-Alsaloop version

### DIFF
--- a/buildroot/package/hifiberry-alsaloop/hifiberry-alsaloop.mk
+++ b/buildroot/package/hifiberry-alsaloop/hifiberry-alsaloop.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HIFIBERRY_ALSALOOP_VERSION =  9c3adeccf60752c1df239be7ec6452c7443fddfb
+HIFIBERRY_ALSALOOP_VERSION = 1bacf8e37b91bd2ae6c72fa6b34a4343dec6f43d
 HIFIBERRY_ALSALOOP_SITE = $(call github,hifiberry,alsaloop,$(HIFIBERRY_ALSALOOP_VERSION))
 
 define SNAPCASTMPRIS_BUILD_CMDS


### PR DESCRIPTION
Update Alsaloop to https://github.com/hifiberry/alsaloop/commit/1bacf8e37b91bd2ae6c72fa6b34a4343dec6f43d.

This update contains:
- Hysteresis
- 15 seconds wait time before stopping when no audio has been received

Related question:
Is `define SNAPCASTMPRIS_BUILD_CMDS endef` in `hifiberry-alsaloop.mk` intentional / necessary, or is this a possible bug?