### PR TITLE
Pause-all: fix single instead of double brackets

### DIFF
--- a/buildroot/package/hifiberry-tools/pause-all
+++ b/buildroot/package/hifiberry-tools/pause-all
@@ -18,7 +18,7 @@ check_paused() {
   PROCESSLINE=`lsof /dev/snd/pcmC*D*p | grep -v COMMAND`
   APP=`echo $PROCESSLINE| awk '{print $1}'`
   PROCESSID=`echo $PROCESSLINE| awk '{print $2}'`
-  if [ "$PLAYER" == "$APP*" ]; then
+  if [[ "$PLAYER" == "$APP*" ]]; then
     echo "$PLAYER ($PPID) requested pause, but is already using sound card, ignoring" | systemd-cat
     exit 0
   fi


### PR DESCRIPTION
This fixes matching in case player has a name longer than 8 characters, while app equals the first 8 characters of player, such as snapclient and snapclien