### PR TITLE
Increase beocreate startup timeout for Pi Zero

### DIFF
--- a/buildroot/package/beocreate/beocreate.mk
+++ b/buildroot/package/beocreate/beocreate.mk
@@ -48,6 +48,11 @@ define BEOCREATE_INSTALL_INIT_SYSTEMD
                 $(TARGET_DIR)/etc/systemd/system/beocreate2.service.d/override.conf
         $(INSTALL) -D -m 0644 $(BR2_EXTERNAL_HIFIBERRY_PATH)/package/beocreate/beocreate2.service \
                 $(TARGET_DIR)/lib/systemd/system/beocreate2.service
+
+	ifeq ($(VERSION),"0w")
+		$(INSTALL) -D -m 0644 $(BR2_EXTERNAL_HIFIBERRY_PATH)/package/beocreate/pi-zero-override.conf \
+			$(TARGET_DIR)/etc/systemd/system/beocreate2.service.d/pi-zero-override.conf
+	endif
 endef
 
 $(eval $(generic-package))

--- a/buildroot/package/beocreate/beocreate2.service
+++ b/buildroot/package/beocreate/beocreate2.service
@@ -18,6 +18,7 @@ RestartSec=10s
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=beocreate2
+TimeoutStartSec=90
 TimeoutStopSec=10
 
 [Install]

--- a/buildroot/package/beocreate/pi-zero-override.conf
+++ b/buildroot/package/beocreate/pi-zero-override.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStartSec=900


### PR DESCRIPTION
#### Status
Draft

#### Content
This tries fixing https://github.com/hifiberry/hifiberry-os/issues/147#issuecomment-774531133 by increasing the startup timeout of the `beocreate2.service` for Pi Zero (W)s to prevent it timing out on them.

I'm not aware of any way to parametrize service files, so I went with an override. Forgive me if this is completely the wrong way. I'm really also no expert on this – especially not with buildroot.