### PR TITLE
Fixes and UNC path sanitization to support SMB shares with spaces

### DIFF
--- a/mount-smb.sh
+++ b/mount-smb.sh
@@ -13,22 +13,19 @@ while read -r line; do
   PASSWORD=$(echo $PASSWORD|tr -d '\n')
   MOUNTOPTS=$(echo $MOUNTOPTS|tr -d '\n')
 
-  echo "DEBUG"
-  echo $USER
   echo "mountid=${MOUNTID}, share=${SHARE}, user=${USER}, passwd=${PASSWORD}, mountopts=${MOUNTOPTS}"
 
   if [ "$MOUNTOPTS" == "" ]; then
     MOUNTOPTS="rw"
   fi
 
-  if [ ! -d '$BASEDIR/$MOUNTID' ]; then
-    mkdir -p '$BASEDIR/$MOUNTID'
+  if [ ! -d $BASEDIR/$MOUNTID ]; then
+    mkdir -p "$BASEDIR/$MOUNTID"
   fi
 
   # Removed local resolving as it leads to SHARE beeing empty if not resolvable
-  mountcmd="mount.cifs '$SHARE' '/data/library/music/$MOUNTID' -o user=$USER,password=$PASSWORD,$MOUNTOPTS"
-  echo ${mountcmd}
-  ${mountcmd}
+  mount.cifs "${SHARE}" "/data/library/music/${MOUNTID}" -o user=$USER,password=$PASSWORD,$MOUNTOPTS
+  echo "${SHARE} mounted on /data/library/music/${MOUNTID}"
 
   if [ -x /opt/hifiberry/bin/report-activation ]; then
     /opt/hifiberry/bin/report-activation mount_samba
@@ -37,7 +34,7 @@ done < /etc/smbmounts.conf
 
 if [ "$1" != "--no-update" ]; then
   if [ -x /opt/hifiberry/bin/update-mpd-db ]; then
-    /opt/hifiberry/bin/update-mpd-db &
+    /opt/hifiberry/bin/update-mpd-db
   fi
 fi
 

--- a/mount-smb.sh
+++ b/mount-smb.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+BASEDIR=/data/library/music
+while read -r line; do
+  readarray -d \; -t parts <<< "$line"
+  MOUNTID=${parts[0]}
+  SHARE=${parts[1]}
+  USER=${parts[2]}
+  PASSWORD=${parts[3]}
+  MOUNTOPTS=${parts[4]}
+
+  # Remove newline from last parameter
+  PASSWORD=$(echo $PASSWORD|tr -d '\n')
+  MOUNTOPTS=$(echo $MOUNTOPTS|tr -d '\n')
+
+  echo "DEBUG"
+  echo $USER
+  echo "mountid=${MOUNTID}, share=${SHARE}, user=${USER}, passwd=${PASSWORD}, mountopts=${MOUNTOPTS}"
+
+  if [ "$MOUNTOPTS" == "" ]; then
+    MOUNTOPTS="rw"
+  fi
+
+  if [ ! -d $BASEDIR/$MOUNTID ]; then
+    mkdir -p $BASEDIR/$MOUNTID
+  fi
+  # Check if share is on a .local host, resolve this first
+  HOST=`echo $m | awk -F\; '{print $2}' | awk -F\/ '{print $3}'`
+  if [[ $HOST == *.local ]]; then
+    IP=`avahi-resolve-host-name -4 $HOST | awk '{print $2}'`
+  fi
+
+  # The try to resolve using nmblookup
+  if [ "$IP" == "" ]; then
+    nmblookup $HOST > /tmp/$$
+    if [ "$?" == "0" ]; then
+      IP=`nmblookup $HOST|awk 'END{print $1}'`
+    fi
+  fi
+
+  if [ "$IP" != "" ]; then
+    SHARE=`echo $SHARE | sed s/$HOST/$IP/`
+  fi
+
+  mountcmd="mount -t cifs -o user=$USER,password=$PASSWORD,$MOUNTOPTS $SHARE /data/library/music/$MOUNTID"
+  echo ${mountcmd}
+  ${mountcmd}
+
+  if [ -x /opt/hifiberry/bin/report-activation ]; then
+    /opt/hifiberry/bin/report-activation mount_samba
+  fi
+done < /etc/smbmounts.conf
+
+if [ "$1" != "--no-update" ]; then
+  if [ -x /opt/hifiberry/bin/update-mpd-db ]; then
+    /opt/hifiberry/bin/update-mpd-db &
+  fi
+fi
+

--- a/mount-smb.sh
+++ b/mount-smb.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 BASEDIR=/data/library/music
 while read -r line; do
+  # Split the line first
   readarray -d \; -t parts <<< "$line"
   MOUNTID=${parts[0]}
   SHARE=${parts[1]}
@@ -20,28 +21,12 @@ while read -r line; do
     MOUNTOPTS="rw"
   fi
 
-  if [ ! -d $BASEDIR/$MOUNTID ]; then
-    mkdir -p $BASEDIR/$MOUNTID
-  fi
-  # Check if share is on a .local host, resolve this first
-  HOST=`echo $m | awk -F\; '{print $2}' | awk -F\/ '{print $3}'`
-  if [[ $HOST == *.local ]]; then
-    IP=`avahi-resolve-host-name -4 $HOST | awk '{print $2}'`
+  if [ ! -d '$BASEDIR/$MOUNTID' ]; then
+    mkdir -p '$BASEDIR/$MOUNTID'
   fi
 
-  # The try to resolve using nmblookup
-  if [ "$IP" == "" ]; then
-    nmblookup $HOST > /tmp/$$
-    if [ "$?" == "0" ]; then
-      IP=`nmblookup $HOST|awk 'END{print $1}'`
-    fi
-  fi
-
-  if [ "$IP" != "" ]; then
-    SHARE=`echo $SHARE | sed s/$HOST/$IP/`
-  fi
-
-  mountcmd="mount -t cifs -o user=$USER,password=$PASSWORD,$MOUNTOPTS $SHARE /data/library/music/$MOUNTID"
+  # Removed local resolving as it leads to SHARE beeing empty if not resolvable
+  mountcmd="mount.cifs '$SHARE' '/data/library/music/$MOUNTID' -o user=$USER,password=$PASSWORD,$MOUNTOPTS"
   echo ${mountcmd}
   ${mountcmd}
 


### PR DESCRIPTION
This pull request solves issues that occur when trying to mount SMB shares that contain spaces in the UNC path. With previous version this leads into multiple issues (incorrect creation of folders, and 'NAS not available' in Beocreat ui). This patch is also refactors the smbmounts.conf as there are race conditions where Beocreate leaves empty lines.
