### PR TITLE
Bugfix/209: Fixes and UNC path sanitization to support SMB shares with spaces

### DIFF
--- a/buildroot/package/hifiberry-automount/mount-smb.sh
+++ b/buildroot/package/hifiberry-automount/mount-smb.sh
@@ -4,6 +4,7 @@ BASEDIR=/data/library/music
 SMB_MOUNT=/etc/smbmounts.conf
 SMB_PATCH=/tmp/smbmounts_patch
 
+
 # Fix for Beocreate: not using proper EOF and handling shares with spaces beeing incorrectly translated to MOUNTID
 if test -f "${SMB_PATCH}"; then
   rm ${SMB_PATCH}

--- a/buildroot/package/hifiberry-automount/mount-smb.sh
+++ b/buildroot/package/hifiberry-automount/mount-smb.sh
@@ -1,54 +1,57 @@
 #!/bin/bash
 BASEDIR=/data/library/music
-for m in `cat /etc/smbmounts.conf | grep -v ^#`; do
+SMB_MOUNT=/etc/smbmounts.conf
+SMB_PATCH=/tmp/smbmounts_patch
 
-  # Split the line first
-  readarray -d \; -t parts <<< "$m"
-  MOUNTID=${parts[0]}
-  SHARE=${parts[1]}
-  USER=${parts[2]}
-  PASSWORD=${parts[3]}
-  MOUNTOPTS=${parts[4]}
+echo "Patching ${SMB_MOUNT}"
+# Fix for Beocreate: not using proper EOF and handling shares with spaces beeing incorrectly translated to MOUNTID
+if test -f "${SMB_PATCH}"; then
+  rm ${SMB_PATCH}
+fi
+touch ${SMB_PATCH}
 
-  # Remove newline from last parameter
-  PASSWORD=$(echo $PASSWORD|tr -d '\n')
-  MOUNTOPTS=$(echo $MOUNTOPTS|tr -d '\n')
-	
-  if [ "$MOUNTOPTS" == "" ]; then
-    MOUNTOPTS="rw"
-  fi
+readarray lines < /etc/smbmounts.conf
+for i in "${lines[@]}"
+do
+  line=`echo $i | xargs`
 
-  if [ ! -d $BASEDIR/$MOUNTID ]; then
-    mkdir -p $BASEDIR/$MOUNTID
-  fi
-  # Check if share is on a .local host, resolve this first
-  HOST=`echo $m | awk -F\; '{print $2}' | awk -F\/ '{print $3}'`
-  if [[ $HOST == *.local ]]; then 
-    IP=`avahi-resolve-host-name -4 $HOST | awk '{print $2}'`
-  fi
+  if [ "$line" != ""  ]; then
+    readarray -d \; -t parts <<< "$line"
+    MOUNTID=`echo "${parts[0]}" | sed -e 's/ //g'` # strip spaces from MOUNTID
+    SHARE="${parts[1]}"
+    USER="${parts[2]}"
+    PASSWORD="${parts[3]//$'\n'}" # fixes newline inserts by Beocreate
+    MOUNTOPTS="${parts[4]//$'\n'}" #
 
-  # The try to resolve using nmblookup
-  if [ "$IP" == "" ]; then
-    nmblookup $HOST > /tmp/$$
-    if [ "$?" == "0" ]; then
-      IP=`nmblookup $HOST|awk 'END{print $1}'`
+    if [ "$MOUNTOPTS" == "" ]; then
+      MOUNTOPTS="rw"
     fi
-  fi
 
-  if [ "$IP" != "" ]; then
-    SHARE=`echo $SHARE | sed s/$HOST/$IP/`
-  fi
+    # Create mount folder
+    if [ ! -d "$BASEDIR/$MOUNTID" ]; then
+      echo "CREATE FOLDER"
+      mkdir -p "$BASEDIR/$MOUNTID"
+    fi
 
-  mountcmd="mount -t cifs -o user=$USER,password=$PASSWORD,$MOUNTOPTS $SHARE /data/library/music/$MOUNTID"
-  echo ${mountcmd}
-  ${mountcmd}
+    echo "mountid=${MOUNTID}, share=${SHARE}, user=${USER}, passwd=${PASSWORD}, mountopts=${MOUNTOPTS}"
+    # mount folder
+    mount.cifs "${SHARE}" "$BASEDIR/$MOUNTID" -o user="${USER}",password="${PASSWORD}","${MOUNTOPTS}"
 
-  if [ -x /opt/hifiberry/bin/report-activation ]; then
-    /opt/hifiberry/bin/report-activation mount_samba
+    if [ -x /opt/hifiberry/bin/report-activation ]; then
+      /opt/hifiberry/bin/report-activation mount_samba
+    fi
+
+    # add fixes to patch file
+    printf "$MOUNTID;$SHARE;$USER;$PASSWORD\n" >> ${SMB_PATCH}
   fi
 done
-if [ "$1" != "--no-update" ]; then 
+
+# apply patched file to /etc/smbmounts.conf, this also fixes ui when UNC path contains space
+mv ${SMB_PATCH} ${SMB_MOUNT}
+
+if [ "$1" != "--no-update" ]; then
   if [ -x /opt/hifiberry/bin/update-mpd-db ]; then
-    /opt/hifiberry/bin/update-mpd-db &
+    /opt/hifiberry/bin/update-mpd-db
   fi
 fi
+

--- a/buildroot/package/hifiberry-automount/mount-smb.sh
+++ b/buildroot/package/hifiberry-automount/mount-smb.sh
@@ -4,7 +4,6 @@ BASEDIR=/data/library/music
 SMB_MOUNT=/etc/smbmounts.conf
 SMB_PATCH=/tmp/smbmounts_patch
 
-echo "Patching ${SMB_MOUNT}"
 # Fix for Beocreate: not using proper EOF and handling shares with spaces beeing incorrectly translated to MOUNTID
 if test -f "${SMB_PATCH}"; then
   rm ${SMB_PATCH}

--- a/buildroot/package/hifiberry-automount/mount-smb.sh
+++ b/buildroot/package/hifiberry-automount/mount-smb.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 BASEDIR=/data/library/music
 SMB_MOUNT=/etc/smbmounts.conf
 SMB_PATCH=/tmp/smbmounts_patch


### PR DESCRIPTION
This pull request solves issues that occur when trying to mount SMB shares that contain spaces in the UNC path. With previous version this leads into multiple issues (incorrect creation of folders, and 'NAS not available' in Beocreat ui). This patch is also refactors the smbmounts.conf as there are race conditions where Beocreate leaves empty lines.