### PR TITLE
Reduce bluetooth buffer time from 250ms to 20ms

### DIFF
--- a/buildroot/package/hifiberry-bluezalsa/bluealsa-aplay-start
+++ b/buildroot/package/hifiberry-bluezalsa/bluealsa-aplay-start
@@ -1,4 +1,4 @@
 #!/bin/sh
 . /etc/hifiberry.state
-/usr/bin/bluealsa-aplay --pcm-buffer-time=250000 00:00:00:00:00:00 --mixer-name=$CURRENT_MIXER_CONTROL
+/usr/bin/bluealsa-aplay --pcm-buffer-time=20000 --pcm-period-time=10000 00:00:00:00:00:00 --mixer-name=$CURRENT_MIXER_CONTROL
 


### PR DESCRIPTION
Follows the bluealsa-aplay `--pcm-buffer-time` and `--pcm-period-time` recommendations from here: https://github.com/Arkq/bluez-alsa/blob/master/doc/bluealsa-aplay.1.rst

Fixes #292. 