### PR TITLE
worth mentioning, how else to know what version?

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -33,6 +33,10 @@ buildroot software.
 
 When building HiFiBerryOS, you should change to the HiFiBerryOS directory first.
 
+### get-buildroot
+
+git clones into the right location a version of buildroot known to work for the checked out version of HiFiBerryOS.
+
 ### clean
  
 Cleans up the buildroot folder. When using this, you have to rebuild the whole system. This can take a long time. 


### PR DESCRIPTION
ie, what version of buildroot to use, for this particular
git version of the os?

I discovered this script while troubleshooting a buildroot issue that seems fixed by using the tag mentioned in get-buildroot.