### PR TITLE
Change mount-smb.sh to authorize mount share path with space 

### DIFF
--- a/buildroot/package/hifiberry-automount/mount-smb.sh
+++ b/buildroot/package/hifiberry-automount/mount-smb.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 BASEDIR=/data/library/music
-for m in `cat /etc/smbmounts.conf | grep -v ^#`; do
-
+# change for m in `cat /etc/smbmounts.conf | grep -v ^#`; do because cut path if there is a space in the share path
+grep -v '^#' /etc/smbmounts.conf  | while read -r m ; do 
   # Split the line first
   readarray -d \; -t parts <<< "$m"
   MOUNTID=${parts[0]}
   SHARE=${parts[1]}
+# add a variable to mount share with space 
+  SHAREMOUNT="'"$SHARE"'";
   USER=${parts[2]}
   PASSWORD=${parts[3]}
   MOUNTOPTS=${parts[4]}
@@ -38,10 +40,11 @@ for m in `cat /etc/smbmounts.conf | grep -v ^#`; do
   if [ "$IP" != "" ]; then
     SHARE=`echo $SHARE | sed s/$HOST/$IP/`
   fi
-
-  mountcmd="mount -t cifs -o user=$USER,password=$PASSWORD,$MOUNTOPTS $SHARE /data/library/music/$MOUNTID"
-  echo ${mountcmd}
-  ${mountcmd}
+# replace SHARE by SHAREMOUNT
+  mountcmd="mount -t cifs -o user=$USER,password=$PASSWORD,$MOUNTOPTS $SHAREMOUNT /data/library/music/$MOUNTID"
+# change execute commante   
+  echo $mountcmd
+  eval $mountcmd
 
   if [ -x /opt/hifiberry/bin/report-activation ]; then
     /opt/hifiberry/bin/report-activation mount_samba
@@ -50,3 +53,4 @@ done
 if [ -x /opt/hifiberry/bin/update-mpd-db ]; then
  /opt/hifiberry/bin/update-mpd-db &
 fi
+# 


### PR DESCRIPTION
I propose a correction to authorize  mount Nas with a space in the share  path

example:
before
impossible because space in the iTunes Media name
mount -t cifs -o user=root,password=password,sec=ntlm,uid=root,rsize=1048576,wsize=65536,vers=1.0 '//192.168.0.12/Data/iTunes/iTunes Media/Music' /data/library/music/1