### PR TITLE
Fix: sample rate xml attribute typos

### DIFF
--- a/buildroot/package/dspprofiles/dsp-addon-96-11.xml
+++ b/buildroot/package/dspprofiles/dsp-addon-96-11.xml
@@ -3,7 +3,7 @@
   <dateTime>2020-06-24T10:16:32.9132938Z</dateTime>
 
 <beometa>
-	<metadata type="sampleRate">96000</metadata>
+	<metadata type="samplerate">96000</metadata>
 	<metadata type="profileName">DSP add-on</metadata>
 	<metadata type="profileVersion">11</metadata>
 	<metadata type="programID">dsp-addon</metadata>

--- a/buildroot/package/dspprofiles/dsp-addon-96-12.xml
+++ b/buildroot/package/dspprofiles/dsp-addon-96-12.xml
@@ -3,7 +3,7 @@
   <dateTime>2020-11-05T13:34:25.8665408Z</dateTime>
   <version>4.5.0.1779</version>
   <beometa>
-	<metadata type="sampleRate">96000</metadata>
+	<metadata type="samplerate">96000</metadata>
  	<metadata type="profileName">DSP add-on</metadata>
         <metadata type="profileVersion">12</metadata>
         <metadata type="programID">dsp-addon</metadata>

--- a/buildroot/package/dspprofiles/dsp-addon-96-13.xml
+++ b/buildroot/package/dspprofiles/dsp-addon-96-13.xml
@@ -3,7 +3,7 @@
   <dateTime>2020-12-08T12:44:00.3255070Z</dateTime>
   <version>4.5.0.1779</version>
   <beometa>
-	<metadata type="sampleRate">96000</metadata>
+	<metadata type="samplerate">96000</metadata>
     <metadata type="profileName">DSP add-on</metadata>
     <metadata type="profileVersion">13</metadata>
     <metadata type="programID">dsp-addon</metadata>

--- a/buildroot/package/dspprofiles/dspdac-10.xml
+++ b/buildroot/package/dspprofiles/dspdac-10.xml
@@ -3,7 +3,7 @@
 	<dateTime>2020-01-27T12:51:25.8469973Z</dateTime>
 	<version>4.2.1.1764</version>
 	<beometa>
-		<metadata type="sampleRate">48000</metadata>
+		<metadata type="samplerate">48000</metadata>
 		<metadata type="profileName">DAC+ DSP Universal</metadata>
 		<metadata type="profileVersion">10</metadata>
 		<metadata type="programID">dacdsp-universal</metadata>

--- a/buildroot/package/dspprofiles/dspdac-11.xml
+++ b/buildroot/package/dspprofiles/dspdac-11.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <ROM IC="ADAU1451" IC_Address="1" Address_byte_length="2">
 <beometa>
-	<metadata type="sampleRate">48000</metadata>
+	<metadata type="samplerate">48000</metadata>
         <metadata type="profileName">DAC+ DSP Universal</metadata>
         <metadata type="profileVersion">11</metadata>
         <metadata type="programID">dacdsp-universal</metadata>

--- a/buildroot/package/dspprofiles/dspdac-12.xml
+++ b/buildroot/package/dspprofiles/dspdac-12.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <ROM IC="ADAU1451" IC_Address="1" Address_byte_length="2">
   <beometa>
-	<metadata type="sampleRate">48000</metadata>
+	<metadata type="samplerate">48000</metadata>
         <metadata type="profileName">DAC+ DSP Universal</metadata>
         <metadata type="profileVersion">12</metadata>
         <metadata type="programID">dacdsp-universal</metadata>

--- a/buildroot/package/dspprofiles/dspdac-96-11.xml
+++ b/buildroot/package/dspprofiles/dspdac-96-11.xml
@@ -2,7 +2,7 @@
 <ROM IC="ADAU1451" IC_Address="1" Address_byte_length="2">
   <dateTime>2020-06-24T16:21:13.0463966Z</dateTime>
 <beometa>
-	 <metadata type="sampleRate">96000</metadata>
+	 <metadata type="samplerate">96000</metadata>
          <metadata type="profileName">DAC+ DSP Universal (96kHz)</metadata>
          <metadata type="profileVersion">11</metadata>
          <metadata type="programID">dacdsp-universal-96</metadata>

--- a/buildroot/package/dspprofiles/generic192.xml
+++ b/buildroot/package/dspprofiles/generic192.xml
@@ -32,7 +32,7 @@
 		<metadata type="delay2">634</metadata>
 		<metadata type="delay3">635</metadata>
 		<metadata type="delay4">636</metadata>
-		<metadata type="sampleRate">192000</metadata>
+		<metadata type="samplerate">192000</metadata>
 		<metadata type="customFilterRegisterBankLeft">132/80</metadata>
 		<metadata type="customFilterRegisterBankRight">52/80</metadata>
 		<metadata type="toneControlLeftRegisters">212/50</metadata>

--- a/buildroot/package/dspprofiles/generic96.xml
+++ b/buildroot/package/dspprofiles/generic96.xml
@@ -3,7 +3,7 @@
 	<beometa>
                 <metadata type="profileName">Generic 96kHz</metadata>
                 <metadata type="profileVersion">20191121</metadata>
-                <metadata type="sampleRate">96000</metadata>
+                <metadata type="samplerate">96000</metadata>
                 <metadata type="checksum">AEE5921C33D71C02C9D14679496B20B3</metadata>
 		<metadata type="volumeLimitPiRegister">4680</metadata>
 		<metadata type="volumeLimitSPDIFRegister">4682</metadata>

--- a/buildroot/package/hifiberry-test/beov10.xml
+++ b/buildroot/package/hifiberry-test/beov10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <ROM IC="ADAU1451" IC_Address="1" Address_byte_length="2">
 	<beometa>
-		<metadata type="sampleRate">48000</metadata>
+		<metadata type="samplerate">48000</metadata>
 		<metadata type="profileName">Beocreate Universal</metadata>
 		<metadata type="profileVersion">10</metadata>
 		<metadata type="programID">beocreate-universal</metadata>


### PR DESCRIPTION
Same fix as hifiberry/hifiberry-dsp#46 but for xml profiles in the OS