### PR TITLE
Make Amp2 detection more reliable

### DIFF
--- a/buildroot/package/hifiberry-tools/detect-hifiberry
+++ b/buildroot/package/hifiberry-tools/detect-hifiberry
@@ -82,7 +82,7 @@ function detect_card {
 
 	# DAC Plus
 	res=`i2cget -y 1 0x4d 40 2>/dev/null`
-	if [ "$res" == "0x02" ]; then
+	if [ "$res" == "0x02" ] || [ "$res" == "0x03" ]; then
                 DETECTED="dacplus"
 		return
         fi


### PR DESCRIPTION
After several test runs of the detect-hifiberry script, it did not detect my Amp2 anymore because `i2cget -y 1 0x4d 40` returned '0x03' as opposed to '0x02'. This behaviour was persistent across system reboots that day. The next day the behaviour started from the beginning, first returning 0x02 and then 0x03.

This pull request makes the `detect-hifiberry` script cover that case as well.

Relates to #416 
Supersedes #418