### PR TITLE
Support pi zero 2

### DIFF
--- a/buildroot/package/hifiberry-tools/reconfigure-players
+++ b/buildroot/package/hifiberry-tools/reconfigure-players
@@ -133,6 +133,13 @@ pi_model() {
   FEATURES="$FEATURES bluetooth"
   return
  fi
+ 
+ if [[ $modelname == *"Pi Zero 2"* ]]; then
+  PIMODEL="4"
+  PIVERSION=4
+  FEATURES="$FEATURES bluetooth pi3orlater arm7"
+  return
+ fi
 
  if [[ $modelname == *"Pi 2 Model"* ]]; then
   PIMODEL="2"

--- a/buildroot/package/hifiberry-tools/reconfigure-players
+++ b/buildroot/package/hifiberry-tools/reconfigure-players
@@ -135,8 +135,8 @@ pi_model() {
  fi
  
  if [[ $modelname == *"Pi Zero 2"* ]]; then
-  PIMODEL="4"
-  PIVERSION=4
+  PIMODEL="02w"
+  PIVERSION=3
   FEATURES="$FEATURES bluetooth pi3orlater arm7"
   return
  fi

--- a/doc/known-problems.md
+++ b/doc/known-problems.md
@@ -1,7 +1,7 @@
 # Known problems
 
 * Spotifyd sometimes crashes. This seems to happen only when it is not active. It will be automatically restarted, but you might still notice that it's not available in the Spotify client
-* Bluetooth volume control does not affect ALSA master volume, but is handled internally. This measn, increasing/decreasing 
+* Bluetooth volume control does not affect ALSA master volume, but is handled internally. This means, increasing/decreasing 
 volume on Bluetooth won't have any effect on other applications.
 This is a limitation of the Bluetooth ALSA software
 * Bluetooth initialisation doesn't work 100% reliable. In case Bluetooth isn't starting up, try rebooting.

--- a/doc/services.md
+++ b/doc/services.md
@@ -6,25 +6,25 @@ The following services are currently supported on HiFiBerryOS:
 * Analog input on DAC+ ADC
 * Bluetooth
 * mpd
-* Roon (not on Raspberry Pi Zero)
-* Spotify (not on Raspberry Pi Zero)
-* Squeezebox (not on Raspberry Pi Zero)
+* Roon (not on the Raspberry Pi Zero)
+* Spotify (not on the Raspberry Pi Zero)
+* Squeezebox (not on the Raspberry Pi Zero)
 * Snapcast (not on the Raspberry Pi Zero)
 
 
 ## Airplay 1
 
-Shairport-sync implements support for the older Airplay 1 protocol. This is still supported today. Airplay 2 that offers 
+Shairport-sync implements support for the older Airplay 1 protocol. This is still supported til today. Airplay 2 offers 
 some additional features is not supported.
 
 ## Analog input
 
-alsaloop is used to enable input from analoge input of the DAC+ ADC cards. It just uses alsaloop to copy data from the input
+alsaloop is used to enable input from a analoge input of the DAC+ ADC cards. It just uses alsaloop to copy data from the input
 to the output.
 
 ## Bluetooth
 
-This module enables HiFiBerryOS to act as a Bluetooth speaker. It uses BlueZ and BlueALSA to implement this. MPRIS is implemented my mpris-proxy
+This module enables HiFiBerryOS to act as a Bluetooth speaker. It uses BlueZ and BlueALSA to implement bluetooth functionalities. MPRIS is implemented using mpris-proxy
 
 ## MPD
 
@@ -45,7 +45,7 @@ Squeezelite implements the Logitech Squeezebox protocol enabling the system to c
 
 ## Snapcast
 
-A snapcast player is included. This is still experimental.
+A snapcast player is included, but is still experimental.
 
 # Systemd services and config files
 

--- a/doc/setupdev.md
+++ b/doc/setupdev.md
@@ -5,7 +5,7 @@ systems. For other Linux distributions, you might have to adapt some of these sc
 
 ## Compilation environment
 
-The system you're using should have at least 16GM RAM (more is better). With the latest addition of Webkit, running on a CPU with many cores/threads (eg. 16/32), 16GB might not be enough memory anymore. You should have at least 1GB RAM per thread (e.g. for e Ryzen 3950X that means 32GB). 
+The system you're using should have at least 16GB RAM (more is better). With the latest addition of Webkit, running on a CPU with many cores/threads (eg. 16/32), 16GB might not be enough memory anymore. You should have at least 1GB RAM per thread (e.g. for e Ryzen 3950X that means 32GB). 
 Using a VM for the compilation works well, but we recommend at least 150GB disk space for it (might not be enough for multiple parallel  builds). An SSD is highly recommended.
 
 We can't recommend the Windows Subsystem for Linux due to it's poor I/O performance. As the build creates, reads and writes a huge amount of files, the build on WSL will be very slow.


### PR DESCRIPTION
Support for Pi Zero 2 W.   Features are enabled similar to PI 3. The OS works stable and responsive so far.  Please note that the correct device table for the pi 0 2 need to be deployed. -> https://github.com/raspberrypi/firmware/blob/master/boot/bcm2710-rpi-zero-2.dtb

