### PR TITLE
mount-smb.sh can now parse shares with space character

### DIFF
--- a/buildroot/package/hifiberry-automount/mount-smb.sh
+++ b/buildroot/package/hifiberry-automount/mount-smb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 BASEDIR=/data/library/music
-for m in `cat /etc/smbmounts.conf | grep -v ^#`; do
+cat /etc/smbmounts.conf | grep -v '^#' | while read -r m; do
 
   # Split the line first
   readarray -d \; -t parts <<< "$m"
@@ -39,9 +39,8 @@ for m in `cat /etc/smbmounts.conf | grep -v ^#`; do
     SHARE=`echo $SHARE | sed s/$HOST/$IP/`
   fi
 
-  mountcmd="mount -t cifs -o user=$USER,password=$PASSWORD,$MOUNTOPTS $SHARE /data/library/music/$MOUNTID"
-  echo ${mountcmd}
-  ${mountcmd}
+  # mount is invoked directly with SHARE quoted to support space-containing paths
+  (set -x; mount -t cifs -o user=$USER,password=$PASSWORD,$MOUNTOPTS "$SHARE" /data/library/music/$MOUNTID)
 
   if [ -x /opt/hifiberry/bin/report-activation ]; then
     /opt/hifiberry/bin/report-activation mount_samba


### PR DESCRIPTION
My home NAS has a file share I wanted to mount with HifiBerryOS which contained a space in its filename ("192.168.0.1/Audio/A Folder" for example). The space would cause a single line of `smbmounts.conf` to be split into two seperate, malformed configuration entries in mount-smb.conf and would cause later issues when evaluating the `mount` command.

This change fixed `mount-smb.sh` to use the `read` built-in to read an entire mount config into a single variable, and then directly evaluates `mount` (while preserving the printing of the commandline) to fix space-evaluation issues.