### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "HifiBerry Devcontainer",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:focal",
+	"mounts": [
+		{
+			"source": "devcontainer-hifiberry-build-cache-${devcontainerId}",
+			"target": "/workspaces",
+			"type": "volume"
+		}
+	],
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash .devcontainer/prepare-devcontainer; bash .devcontainer/prepare-devcontainer --fix-symlinks",
+	// Configure tool-specific properties.
+	"customizations": { // Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-vscode.makefile-tools"
+			]
+		}
+		// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+		// "remoteUser": "root"
+	}
+}

--- a/.devcontainer/prepare-devcontainer
+++ b/.devcontainer/prepare-devcontainer
@@ -1,0 +1,42 @@
+#!/bin/bash
+if [ "$1" = "" ]
+then
+    echo "Preparing devcontainer - installing dependencies"
+    sudo apt update
+    # install dependencies with bundled script
+    bash prepare-software
+    # install additional dependencies needed for build (not included in devcontainer base image)
+    sudo apt-get -y install file cpio
+
+    echo "Preparing devcontainer - adjusting permissions"
+    # everything should be owned by container vscode user
+    sudo chown -R vscode:vscode /workspaces/
+
+    echo "Preparing devcontainer - getting buildroot"
+    # get buildroot with bundled script
+    bash get-buildroot
+
+elif [ "$1" = "--remove-problematic-symlinks" ]; then
+    # Symblinks might have been malformated when cloning thte repository - remove all
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+    rm -v $SCRIPT_DIR/../buildroot/package/spotifyd/spotifyd.mk
+
+    rm -v $SCRIPT_DIR/../buildroot/board/raspberrypi0w \
+        $SCRIPT_DIR/../buildroot/board/raspberrypi2 \
+        $SCRIPT_DIR/../buildroot/board/raspberrypi3 \
+        $SCRIPT_DIR/../buildroot/board/raspberrypi4
+
+elif [ "$1" = "--fix-symlinks" ]; then
+    # Symblinks might have been malformated when cloning thte repository - recreate all (experimental)
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+    bash $SCRIPT_DIR/prepare-devcontainer --remove-problematic-symlinks
+
+    ln -sv spotifyd-bin-mk $SCRIPT_DIR/../buildroot/package/spotifyd/spotifyd.mk
+
+    ln -sv raspberrypi $SCRIPT_DIR/../buildroot/board/raspberrypi0w
+    ln -sv raspberrypi $SCRIPT_DIR/../buildroot/board/raspberrypi2
+    ln -sv raspberrypi $SCRIPT_DIR/../buildroot/board/raspberrypi3
+    ln -sv raspberrypi $SCRIPT_DIR/../buildroot/board/raspberrypi4
+fi

--- a/doc/setupdev.md
+++ b/doc/setupdev.md
@@ -5,14 +5,14 @@ systems. For other Linux distributions, you might have to adapt some of these sc
 
 ## Compilation environment
 
-The system you're using should have at least 16GB RAM (more is better). With the latest addition of Webkit, running on a CPU with many cores/threads (eg. 16/32), 16GB might not be enough memory anymore. You should have at least 1GB RAM per thread (e.g. for e Ryzen 3950X that means 32GB). 
+The system you're using should have at least 16GB RAM (more is better). With the latest addition of Webkit, running on a CPU with many cores/threads (eg. 16/32), 16GB might not be enough memory anymore. You should have at least 1GB RAM per thread (e.g. for e Ryzen 3950X that means 32GB).
 Using a VM for the compilation works well, but we recommend at least 150GB disk space for it (might not be enough for multiple parallel  builds). An SSD is highly recommended.
 
 We can't recommend the Windows Subsystem for Linux due to it's poor I/O performance. As the build creates, reads and writes a huge amount of files, the build on WSL will be very slow.
 
 Our build system uses an Ryzen 3950X with 64GB RAM (max. 50MB to the build VM) and 300GB SSD disk space. This allows to run multiple build (e.g. Pi 2,3,4) in parallel.
- 
-In any case, expect a full build to take at least 50 minutes on a high-end system (>80 minutes for newer versions that include the local graphical interface) and much longer on slower systems. 
+
+In any case, expect a full build to take at least 50 minutes on a high-end system (>80 minutes for newer versions that include the local graphical interface) and much longer on slower systems.
 
 ## Checkout HiFiBerryOS sources
 
@@ -53,5 +53,34 @@ This will take some time. Depending on your hardware and network connectivity, e
 
 ## Parallel builds
 
-Builds for a specific platform (e.g. Pi3 or Pi4) are store in separate directories. This means you can run a parallel builds for multiple platforms. Especially for systems with a lots of cores and fast SSDs, this is usually faster than running 
-them sequentially. 
+Builds for a specific platform (e.g. Pi3 or Pi4) are store in separate directories. This means you can run a parallel builds for multiple platforms. Especially for systems with a lots of cores and fast SSDs, this is usually faster than running them sequentially.
+
+# Using the .devcontainer (experimental)
+
+The HiFiBerryOS repository comes with a definition of a [VS Code Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) - so if you have Docker set up and are using VS Code you can just start this repository in your container.
+If you are using Windows as host system please clone the repository using the correct line ending setting, e.g.:
+```bash
+git clone git@github.com:hifiberry/hifiberry-os.git --config core.autocrlf=input
+```
+Especially if your `--system`-wide or `--global` git config uses `core.autocrlf=true`.
+
+The container build will automatically
+* install the necessary tools as seen in [Install necessary tools](#install-necessary-tools)
+* make sure the working folders (i.e., `/workspaces/`) is owned by the `vscode` user of the container
+* keep anything in ``/workspaces/`` in a Docker volume for faster consecutive builds (beware, this also mounts the git repo into that volume of which possible interference is untested)
+* fix symlinks that break when cloning on Windows
+* run the [`get-buildroot` command](#download-and-extract-buildroot)
+
+for you (see [prepare script](../.devcontainer/prepare-devcontainer)).
+The only thing left to do is follow the instruction of [Start the first build](#start-the-first-build)
+
+:warning: **Build experience inside the Dev Container might be much poorer than bare metal.**
+
+## Troubleshooting
+* If you cloned the HiFiBerryOs repository under Windows and you encounter an issue in the devcontainer with the symlinks of `buildroot/package/spotifyd/spotifyd.mk` and `./buildroot/board/` setting up the devcontainer seems to have gone wrong as those should have been recreated during container build. In any case there is a script to fix those:
+
+        ./.devcontainer/prepare-devcontainer --fix-symlinks
+
+    This most likely results from cloning without the correct line endings (LF) set. Make sure you cloned the repository specifying `--config core.autocrlf=input`
+* Beware of [this build issue](https://github.com/hifiberry/hifiberry-os/issues/142) resulting in the error `"Advanced Micro Devices X86-64", should be "ARM"`.
+* In case anything stops working try rebuilding the VS Code Dev Container. Beware: there is a chance this might remove any already available build results living in a different docker volume (experimental).


### PR DESCRIPTION
Hi there 👋  
I recently stumbled upon this project and adopted it (with a Pi3+ and your Amp2) in my home for some audio playback over AirPlay. I'm new to using `buildroot` (and embedded itself) but born out of the intention of trying to update the shairplay dependency I started with getting a build running. As a VS Code and Docker user I started off by adding a .devcontainer definition to get the build running on my windows machine (which I did - thanks to your documentation which makes it quite easy to surpass any hurdles along the way).  
If you think this is a valuable addition I'm happy to incorporate any additions that you add to this PR - or close it again if you disagree 😆  