### PR TITLE
Revert "Make Amp2 detection more reliable"

### DIFF
--- a/buildroot/package/hifiberry-tools/detect-hifiberry
+++ b/buildroot/package/hifiberry-tools/detect-hifiberry
@@ -82,7 +82,7 @@ function detect_card {
 
 	# DAC Plus
 	res=`i2cget -y 1 0x4d 40 2>/dev/null`
-	if [ "$res" == "0x02" ] || [ "$res" == "0x03" ]; then
+	if [ "$res" == "0x02" ]; then
                 DETECTED="dacplus"
 		return
         fi


### PR DESCRIPTION
Reverts hifiberry/hifiberry-os#419

I noticed during script reruns at some point that the i2cget test call returned more unexpected values.
Thus, my previous change was pointless.
(Instead, I am making sure to run the `detect-hifiberry` script only once per host.)