### PR TITLE
update shairport-sync to 4.2

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,11 @@
+Unreleased:
+- Updated [shairport-sync](https://github.com/mikebrady/shairport-sync) to version 4.2 ([release notes](https://github.com/mikebrady/shairport-sync/releases/tag/4.2)) and as required [nqptp](https://github.com/mikebrady/nqptp) to version 1.2.1 ([release notes](https://github.com/mikebrady/nqptp/releases/tag/1.2.1))
+
+20230404:
+- Fix several DSP bugs
+- Fix screensaver bug
+- Fix UI bug when no samplerate is defined
+
 20230223:
 - DAC+ DSP profile v13 that is compatible with the latest DAC+ DSP hardware
 
@@ -7,7 +15,7 @@
 
 20221109:
 - improve Digi2 Pro detection
-- improve volume control of Amp3/DSP add-on 
+- improve volume control of Amp3/DSP add-on
 
 20221028:
 - Upgrade Linux kernel
@@ -35,7 +43,7 @@
 - Update kernel to 5.10.95
 - Update to buildroot 2021.11
 - Updated shairport-sync
-- audiocontrol2 websocket API by @schnabel 
+- audiocontrol2 websocket API by @schnabel
 - Bugfix: Set host name on MDNS when it changes
 - Bugfix: Shiaport-sync/nqptp
 
@@ -173,7 +181,7 @@
 - support setting maximum volume and mono/stereo mode for non-DSP sound cards
 - equalizer settings: A/B comparisson
 - support delay for DSP channels
-- named listening modes can be stored and activated 
+- named listening modes can be stored and activated
 - added automatic updates
 - improved metadata handling with radio stations
 - Squeezelite: Allow setting server address
@@ -181,7 +189,7 @@
 - Several other bugfixes and improvements
 
 20260226:
-- Bugfix: Spotify configuration 
+- Bugfix: Spotify configuration
 
 20200225:
 - Bugfix: ympd not using IPv6
@@ -262,9 +270,9 @@ Known problems:
 - Bugfix: Digi+ got stuck in previous release
 
 20190926
-- Added a central config file /etc/hifibery.conf that can be used to 
+- Added a central config file /etc/hifibery.conf that can be used to
   configure the whole system
-- Changed sound card reconfiguration that there is no plop sound 
+- Changed sound card reconfiguration that there is no plop sound
   during startup anymore
 - Added MPD web interface
 - Added player web interface
@@ -282,21 +290,21 @@ Known problems:
 - Added MPD
 - DSPToolkit version 0.17
 - Changed init system to use systemd (faster startup)
-- Removed audiocontrol (as it will be replaced by audiocontrol2 
+- Removed audiocontrol (as it will be replaced by audiocontrol2
   in the future)
 
 20181015
-- Added audiocontrol demon to support volume control 
+- Added audiocontrol demon to support volume control
   via rotary controller
-- DSPTookit upgraded to 0.14 which supports log scale 
+- DSPTookit upgraded to 0.14 which supports log scale
   for shairport-sync
 
 20181011
 - Bugfix: DSPToolkit upgraded to 0.13
-- Bugfix: Shairport now working (some libraries were missing in 
+- Bugfix: Shairport now working (some libraries were missing in
   previous version)
 
-20181009 
+20181009
 - added nano to allow editing local files
 - added WiFi support
 

--- a/buildroot/package/hifiberry-shairport/hifiberry-shairport.mk
+++ b/buildroot/package/hifiberry-shairport/hifiberry-shairport.mk
@@ -4,12 +4,12 @@
 #
 ################################################################################
 
-HIFIBERRY_SHAIRPORT_VERSION = a30c260ec575e6d76d35b72db1343c149ea0772d
+HIFIBERRY_SHAIRPORT_VERSION = b56d55151890ff846a667b50d15e9e6b562144d2
 HIFIBERRY_SHAIRPORT_SITE = $(call github,mikebrady,shairport-sync,$(HIFIBERRY_SHAIRPORT_VERSION))
 
 HIFIBERRY_SHAIRPORT_LICENSE = MIT, BSD-3-Clause
 HIFIBERRY_SHAIRPORT_LICENSE_FILES = LICENSES
-HIFIBERRY_SHAIRPORT_DEPENDENCIES = alsa-lib libconfig libdaemon popt host-pkgconf avahi 
+HIFIBERRY_SHAIRPORT_DEPENDENCIES = alsa-lib libconfig libdaemon popt host-pkgconf avahi
 
 # git clone, no configure
 HIFIBERRY_SHAIRPORT_AUTORECONF = YES
@@ -20,7 +20,7 @@ HIFIBERRY_SHAIRPORT_CONF_OPTS = --with-alsa \
         --with-stdout \
         --with-avahi \
         --with-mpris-interface \
-        --with-mpris-test-client 
+        --with-mpris-test-client
 
 HIFIBERRY_SHAIRPORT_CONF_ENV += LIBS="$(HIFIBERRY_SHAIRPORT_CONF_LIBS)"
 

--- a/buildroot/package/nqptp/nqptp.mk
+++ b/buildroot/package/nqptp/nqptp.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-NQPTP_VERSION = c71b49a3556ba8547ee28482cb31a97fe99298aa
+NQPTP_VERSION = 57fc7ac20ffd7a04ea5fbed6417e4c658bb7eb68
 NQPTP_SITE = $(call github,mikebrady,nqptp,$(NQPTP_VERSION))
 
 # git clone, no configure

--- a/doc/multiroom.md
+++ b/doc/multiroom.md
@@ -2,10 +2,10 @@
 
 ## Airplay
 
-Originally, Airplay wasn't designed for multiroom applications. Apple now used Airplay 2 
-(there are no open source implementations of this!) for multiroom audio.
-However, even the "normal" Airplay can be used to stream to multiple endpoints. The bad news:
-this doesn't work from your iPhone or iPad, but only from iTunes.  
+Originally, Airplay wasn't designed for multiroom applications which changed when Apple
+introduced Airplay 2. The included [shairport](https://github.com/mikebrady/shairport-sync)
+open source implementation uses Airplay 2 and should let your HifiBerry work as Airplay
+speaker from any iOS device.
 
 ## LMS / squeezelite
 
@@ -15,15 +15,15 @@ and the configuration (especially with plugins) can be a bit challenging, have a
 
 ## Snapcast
 
-Snapcast is an open-source multiroom client-server audio player, where all clients are time synchronized with the server 
-to play perfectly synced audio. It's not a standalone player, but an extension that turns your existing audio player 
-into a Sonos-like multiroom solution. You can find the official repository at 
+Snapcast is an open-source multiroom client-server audio player, where all clients are time synchronized with the server
+to play perfectly synced audio. It's not a standalone player, but an extension that turns your existing audio player
+into a Sonos-like multiroom solution. You can find the official repository at
 [github.com/badaix/snapcast](https://github.com/badaix/snapcast).
 
 ## Roon
 
 This is the "luxury" multiroom solutions. While Roon, isn't cheap, the sound quality is great and
-it has very powerful multiroom capabilities. From the Roon client on the mobile phone (or on your PC), 
-you  can easily hand an audio session over from one room to another. You can also group multiple 
+it has very powerful multiroom capabilities. From the Roon client on the mobile phone (or on your PC),
+you  can easily hand an audio session over from one room to another. You can also group multiple
 endpoints to stream the same audio synchronized to multiple endpoints.
 

--- a/doc/services.md
+++ b/doc/services.md
@@ -2,7 +2,7 @@
 
 The following services are currently supported on HiFiBerryOS:
 
-* Airplay 1
+* Airplay 1 and 2
 * Analog input on DAC+ ADC
 * Bluetooth
 * mpd
@@ -12,10 +12,9 @@ The following services are currently supported on HiFiBerryOS:
 * Snapcast (not on the Raspberry Pi Zero)
 
 
-## Airplay 1
+## Airplay 1 and 2
 
-Shairport-sync implements support for the older Airplay 1 protocol. This is still supported til today. Airplay 2 offers 
-some additional features is not supported.
+Shairport-sync implements support for Airplay 1 and 2.
 
 ## Analog input
 
@@ -37,11 +36,11 @@ Roon is a high-end music player. It uses a proprietary protocol. Therefore, the 
 
 ## Spotifyd
 
-Spotifyd implements a Spotify connect receiver. 
+Spotifyd implements a Spotify connect receiver.
 
 ## Squeezelite
 
-Squeezelite implements the Logitech Squeezebox protocol enabling the system to connect to a Logitech Media Server. MPRIS support is implemented separataly by lms-mpris. 
+Squeezelite implements the Logitech Squeezebox protocol enabling the system to connect to a Logitech Media Server. MPRIS support is implemented separataly by lms-mpris.
 
 ## Snapcast
 


### PR DESCRIPTION
Updating `shairport-sync` to 4.2  also required updating `nqptp` to 1.2.1.  
I have the build result up and running (so far smoothly) here on mi Pi 3.

Closes #461 