### PR TITLE
Patch 1

### DIFF
--- a/buildroot/package/hifiberry-tools/detect-hifiberry
+++ b/buildroot/package/hifiberry-tools/detect-hifiberry
@@ -4,7 +4,10 @@
 # in that case we would then create a new config.txt and trigger a reboot.
 # after reboot we might be lucky, or do another loop.....
 # Fix: be more patient: wait 2 secs
-sleep 2
+FOUND=`aplay -l|grep hifiberry | grep -v "pcm5102"`
+if [ -z "$FOUND" ]; then
+  sleep 2
+fi
 
 # On the Pi Zero, volume controls won't show up before playing something :(
 SOFTVOL=`amixer | grep Softvol`

--- a/buildroot/package/hifiberry-tools/detect-hifiberry
+++ b/buildroot/package/hifiberry-tools/detect-hifiberry
@@ -6,6 +6,11 @@ if [ "$SOFTVOL" == "" ]; then
  play -n trim 0 0.1
 fi
 
+# sometimes the alsa device is LATE and aplay deliver a empty result.
+# in that case we would create a new config.txt and trigger a reboot...
+# Fix: be more patient: wait 2 secs
+sleep 2
+
 FOUND=`aplay -l|grep hifiberry | grep -v "pcm5102"`
 CONFIG=/boot/config.txt
 REBOOTFILE=/tmp/reboot

--- a/buildroot/package/hifiberry-tools/detect-hifiberry
+++ b/buildroot/package/hifiberry-tools/detect-hifiberry
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# sometimes the alsa device is LATE and aplay deliver a empty result.
-# in that case we would create a new config.txt and trigger a reboot...
+# sometimes the alsa device is LATE and 'aplay -l' delivers a empty result.
+# in that case we would then create a new config.txt and trigger a reboot.
+# after reboot we might be lucky, or do another loop.....
 # Fix: be more patient: wait 2 secs
 sleep 2
 

--- a/buildroot/package/hifiberry-tools/detect-hifiberry
+++ b/buildroot/package/hifiberry-tools/detect-hifiberry
@@ -1,15 +1,15 @@
 #!/bin/bash
 
+# sometimes the alsa device is LATE and aplay deliver a empty result.
+# in that case we would create a new config.txt and trigger a reboot...
+# Fix: be more patient: wait 2 secs
+sleep 2
+
 # On the Pi Zero, volume controls won't show up before playing something :(
 SOFTVOL=`amixer | grep Softvol`
 if [ "$SOFTVOL" == "" ]; then
  play -n trim 0 0.1
 fi
-
-# sometimes the alsa device is LATE and aplay deliver a empty result.
-# in that case we would create a new config.txt and trigger a reboot...
-# Fix: be more patient: wait 2 secs
-sleep 2
 
 FOUND=`aplay -l|grep hifiberry | grep -v "pcm5102"`
 CONFIG=/boot/config.txt


### PR DESCRIPTION
# sometimes the alsa device is LATE and 'aplay -l' delivers a empty result.
# in that case we would then create a new config.txt and trigger a reboot.
# after reboot we might be lucky, or do another loop.....
# Fix: be more patient: wait 2 secs