### PR TITLE
Update documentation to replace vollibrespot with spotifyd

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The user interface is based on the [Bang & Olufsen Beocreate project](https://gi
 
 At the moment, the following services are supported:
 
-- Spotify (using [a fork of Spotifyd](https://github.com/hifiberry/spotifyd)) - requires a paid Spotify subscription
+- Spotify (using a fork of [vollibrespot](https://github.com/hifiberry/vollibrespot)) - requires a paid Spotify subscription
 - Airplay (using [shairport](https://github.com/mikebrady/shairport-sync))
 - Squeezebox (using [squeezelite](https://github.com/ralph-irving/squeezelite))
 - Bluetooth A2DP sink (using [BlueZ 5](http://www.bluez.org/))

--- a/doc/dbus.md
+++ b/doc/dbus.md
@@ -2,7 +2,9 @@
 
 ## Play/Pause
 
-### Spotify
+### Spotifyd
+
+*By default, hifiberry uses `volllibrespot` not `spotifyd` to provide Spotify playback. `vollibrespot` does not support `dbus`.* 
 
 dbus-send --system --print-reply --type=method_call --dest=org.mpris.MediaPlayer2.spotifyd /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Pause
 

--- a/doc/mpris.md
+++ b/doc/mpris.md
@@ -7,7 +7,8 @@ Today not all applications support MPRIS. This is the current state of MPRIS imp
 
 | Player | MPRIS supported | MPRIS metadata |  Implemented
 | --- | --- | --- |  --- |
-| spotifyd | yes | yes |  yes |
+| spotifyd[^1] | yes | yes |  yes |
+| vollibrespot[^1] | no | no |  no |
 | shairport-sync  | yes | yes |  yes |
 | squeezelite | [lmsmpris](https://github.com/hifiberry/lmsmpris) | yes | yes |
 | bluez-alsa | [mpris-proxy](https://github.com/Vudentz/BlueZ/blob/master/tools/mpris-proxy.c) | yes | yes | 
@@ -15,3 +16,6 @@ Today not all applications support MPRIS. This is the current state of MPRIS imp
 | mpd | [mpd mpris](https://github.com/natsukagami/mpd-mpris) | yes | yes |
 | alsaloop | via  | no | yes |
 | gmediarender | [dlna-mpris](https://github.com/hifiberry/dlna-mpris) | yes | yes |
+
+
+[^1]: The default Spotify provider is `vollibrespot`.

--- a/doc/services.md
+++ b/doc/services.md
@@ -34,9 +34,9 @@ MPRIS is implemented using mpd-mpris.
 
 Roon is a high-end music player. It uses a proprietary protocol. Therefore, the sources for this player are not included.
 
-## Spotifyd
+## Vollibrespot
 
-Spotifyd implements a Spotify connect receiver.
+Vollibrespot implements a Spotify connect receiver.
 
 ## Squeezelite
 
@@ -55,6 +55,6 @@ A snapcast player is included, but is still experimental.
 |mpd|/etc/mpd.conf|mpd.service, mpd-mpris.service|
 |roon|/etc/hifiberry_raat.conf|raat.service|
 |shairport-sync|/etc/shairport-sync.conf|shairport-sync.service|
-|spotifyd|/etc/spotifyd.conf|spotify.service|
+||/etc/vollibrespot.conf|vollibrespot.service|
 |squeezelite|/var/squeezelite/squeezelite.name|squeezelite.service, lmsmpris.service|
 |snapcast|/etc/snapcastmpris.conf|snapcastmpris.service|


### PR DESCRIPTION
As per #496.

`vollibrespot` is now used instead of `spotifyd` by default. This PR updates the documentation to reflect this. 

* In `services.md` and `README`, references with `spotifyd` are replaced with `vollibrespot` outright.
* In the dbus and MPRIS documentation, an explanatory note is provided that `vollibrespot` is now default. While it is no longer in the build, `spotifyd` configuration still exists in the repo, so having this information still here may be valuable should work on the `spotifyd` player resume.