### PR TITLE
Fix `alsaloop` service failing to start

### DIFF
--- a/buildroot/package/hifiberry-alsaloop/dbus.conf
+++ b/buildroot/package/hifiberry-alsaloop/dbus.conf
@@ -1,0 +1,13 @@
+<!-- This configuration file specifies the required security policies
+     for alsaloop daemon to work. -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+ <!-- Root can own the alsaloop service -->
+  <policy user="root">
+    <allow own="org.mpris.MediaPlayer2.alsaloop"/>
+  </policy>
+
+</busconfig>

--- a/buildroot/package/hifiberry-alsaloop/hifiberry-alsaloop.mk
+++ b/buildroot/package/hifiberry-alsaloop/hifiberry-alsaloop.mk
@@ -10,6 +10,8 @@ HIFIBERRY_ALSALOOP_SITE = $(call github,hifiberry,alsaloop,$(HIFIBERRY_ALSALOOP_
 define HIFIBERRY_ALSALOOP_INSTALL_TARGET_CMDS
         mkdir -p $(TARGET_DIR)/opt/alsaloop
 	cp -rv $(@D)/* $(TARGET_DIR)/opt/alsaloop
+	$(INSTALL) -D -m 0644 $(BR2_EXTERNAL_HIFIBERRY_PATH)/package/hifiberry-alsaloop/dbus.conf \
+			$(TARGET_DIR)/etc/dbus-1/system.d/alsaloop.conf
 endef
 
 


### PR DESCRIPTION
This PR partially fixes the alsaloop service failing to start by adding the necessary D-Bus configuration file.