### PR TITLE
Hats:Add ADC, missing UUIDs and all dt_blob definitions

### DIFF
--- a/buildroot/package/hattools/eeprom/adc.txt
+++ b/buildroot/package/hattools/eeprom/adc.txt
@@ -16,22 +16,20 @@
 
 # 128 bit UUID. If left at zero eepmake tool will auto-generate
 # RFC 4122 compliant UUID
-product_uuid fcb6ec42-a182-419d-a314-7eeae416f608
-
+product_uuid e6204ae4-75d7-460a-9e89-3dcd94cfd702
 # 16 bit product id
 product_id 0x0000
 
 # 16 bit product version
-product_ver 0x0000
+product_ver 0x0001
 
 # ASCII vendor string  (max 255 characters)
 vendor "HiFiBerry"
 
 # ASCII product string (max 255 characters)
-product "Amp4"
+product "ADC"
 
-#devicetree overlay
-dt_blob "hifiberry-amp4"
+dt_blob "hifiberry-adc"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.
@@ -54,7 +52,7 @@ gpio_hysteresis 0
 # 3 = reserved
 # If back_power=2 then USB high current mode will be automatically
 # enabled on the Pi
-back_power 2
+back_power 0
 
 ########################################################################
 # GPIO pins, uncomment for GPIOs used on board

--- a/buildroot/package/hattools/eeprom/amp100.txt
+++ b/buildroot/package/hattools/eeprom/amp100.txt
@@ -16,7 +16,7 @@
 
 # 128 bit UUID. If left at zero eepmake tool will auto-generate
 # RFC 4122 compliant UUID
-product_uuid 00000000-0000-0000-0000-000000000000
+product_uuid b1a57dbe-8b52-447f-939e-1baf72157d79
 
 # 16 bit product id
 product_id 0x0000
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "Amp100"
 
+#devicetree overlay
+dt_blob "hifiberry-amp100"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/amp4pro.txt
+++ b/buildroot/package/hattools/eeprom/amp4pro.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "Amp4 Pro"
 
+#devicetree overlay
+dt_blob "hifiberry-amp4pro"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/beocreate2.txt
+++ b/buildroot/package/hattools/eeprom/beocreate2.txt
@@ -16,8 +16,7 @@
 
 # 128 bit UUID. If left at zero eepmake tool will auto-generate
 # RFC 4122 compliant UUID
-product_uuid 00000000-0000-0000-0000-000000000000
-
+product_uuid c05bce95-fa8d-4cde-a7c2-827abfd49c80
 # 16 bit product id
 product_id 0x0000
 
@@ -29,6 +28,9 @@ vendor "HiFiBerry"
 
 # ASCII product string (max 255 characters)
 product "Beocreate 4CA"
+
+#devicetree overlay
+dt_blob "hifiberry-dac"
 
 
 ########################################################################

--- a/buildroot/package/hattools/eeprom/compile-eep
+++ b/buildroot/package/hattools/eeprom/compile-eep
@@ -12,3 +12,4 @@ eepmake beocreate2.txt beocreate2.eep
 eepmake digi2standard.txt digi2standard.eep
 eepmake amp4.txt amp4.eep
 eepmake amp4pro.txt amp4pro.eep
+eepmake adc.txt adc.eep

--- a/buildroot/package/hattools/eeprom/dac2.txt
+++ b/buildroot/package/hattools/eeprom/dac2.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC+"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplus"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dac2adcpro.txt
+++ b/buildroot/package/hattools/eeprom/dac2adcpro.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC2 ADC Pro"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplusadcpro"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dac2hd.txt
+++ b/buildroot/package/hattools/eeprom/dac2hd.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC 2 HD"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplushd"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dac2pro.txt
+++ b/buildroot/package/hattools/eeprom/dac2pro.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC2 Pro"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplus-pro"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dac8x.txt
+++ b/buildroot/package/hattools/eeprom/dac8x.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC8x"
 
+#devicetree overlay
+dt_blob "hifiberry-dac8x"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dacplus.txt
+++ b/buildroot/package/hattools/eeprom/dacplus.txt
@@ -16,7 +16,7 @@
 
 # 128 bit UUID. If left at zero eepmake tool will auto-generate
 # RFC 4122 compliant UUID
-product_uuid 00000000-0000-0000-0000-000000000000
+product_uuid ef586afc-2efa-47a0-be2e-95a7d952fe98
 
 # 16 bit product id
 product_id 0x0000
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC+"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplus-slave"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dacplusadc.txt
+++ b/buildroot/package/hattools/eeprom/dacplusadc.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC+ ADC"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplusadc"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dacplusadcpro.txt
+++ b/buildroot/package/hattools/eeprom/dacplusadcpro.txt
@@ -16,7 +16,7 @@
 
 # 128 bit UUID. If left at zero eepmake tool will auto-generate
 # RFC 4122 compliant UUID
-product_uuid 00000000-0000-0000-0000-000000000000
+product_uuid 36e3d3da-1ed9-468b-aea3-cd165f6820f0
 
 # 16 bit product id
 product_id 0x0000
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DAC+ ADC Pro"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplusadcpro"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/digi2pro.txt
+++ b/buildroot/package/hattools/eeprom/digi2pro.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "Digi2 Pro"
 
+#devicetree overlay
+dt_blob "hifiberry-digi-pro"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/digi2standard.txt
+++ b/buildroot/package/hattools/eeprom/digi2standard.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "Digi2 Standard"
 
+#devicetree overlay
+dt_blob "hifiberry-digi"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/digiplus.txt
+++ b/buildroot/package/hattools/eeprom/digiplus.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "Digi+"
 
+#devicetree overlay
+dt_blob "hifiberry-digi"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/digipro.txt
+++ b/buildroot/package/hattools/eeprom/digipro.txt
@@ -16,7 +16,7 @@
 
 # 128 bit UUID. If left at zero eepmake tool will auto-generate
 # RFC 4122 compliant UUID
-product_uuid 00000000-0000-0000-0000-000000000000
+product_uuid 5af941bb-4dcf-4eac-82a8-e36e84fcabef
 
 # 16 bit product id
 product_id 0x0000
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "Digi+ Pro"
 
+#devicetree overlay
+dt_blob "hifiberry-digi-pro"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/eeprom/dsp2x4.txt
+++ b/buildroot/package/hattools/eeprom/dsp2x4.txt
@@ -30,6 +30,8 @@ vendor "HiFiBerry"
 # ASCII product string (max 255 characters)
 product "DSP 2x4"
 
+#devicetree overlay
+dt_blob "hifiberry-dacplus-dsp"
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.

--- a/buildroot/package/hattools/uuid.txt
+++ b/buildroot/package/hattools/uuid.txt
@@ -1,3 +1,4 @@
+e6204ae4-75d7-460a-9e89-3dcd94cfd702,ADC            ,hifiberry-adc
 5eb863b8-12f9-41ad-978f-4cee1b3eca62,Amp 100        ,hifiberry-amp100
 b1a57dbe-8b52-447f-939e-1baf72157d79,Amp 100        ,hifiberry-amp100
 3619722a-c92d-4092-95bd-493a2903e933,Amp4 Pro       ,hifiberry-amp4pro
@@ -13,3 +14,4 @@ f65985f9-5354-4457-ae3b-3da39ba2cf6d,DAC 8x         ,hifiberry-dac8x
 5af941bb-4dcf-4eac-82a8-e36e84fcabef,Digi2 Pro      ,hifiberry-digi-pro
 7c980a0e-9d15-40af-9f40-bddfbd3aee8c,Digi2 Standard ,hifiberry-digi
 8f287583-429d-4206-a751-862264bbda63,DSP 2x4        ,hifiberry-dacplus-dsp
+c05bce95-fa8d-4cde-a7c2-827abfd49c80,Beocreate2,    ,hifiberry-dac


### PR DESCRIPTION
Adds the ADC eeprom settings and UUIDs for
AMP100
Beocreate2
DAC+
DAC+ADC Pro
Digi Pro

Adds also the overlay names (dt_blobs)