### PR TITLE
spotify: remove hardcoded ip for ap-gew4.spotify.com

### DIFF
--- a/buildroot/package/spotifyd/spotify.service
+++ b/buildroot/package/spotifyd/spotify.service
@@ -12,7 +12,6 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 Environment=SPOTIFYD_CLIENT_ID=9223bb6a6d924c8da9b02519d03c987a
 ExecStartPre=/opt/hifiberry/bin/bootmsg "Starting Spotify"
 ExecStartPre=/opt/hifiberry/bin/store-volume /tmp/spotifyvol
-ExecStartPre=/opt/hifiberry/bin/set-host-ip ap-gew4.spotify.com 104.199.65.124
 ExecStart=/opt/hifiberry/bin/spotify-start
 ExecStartPost=sleep 1
 ExecStartPost=/opt/hifiberry/bin/restore-volume /tmp/spotifyvol

--- a/buildroot/package/vollibrespot/vollibrespot.service
+++ b/buildroot/package/vollibrespot/vollibrespot.service
@@ -8,7 +8,6 @@ ConditionPathExists=!/custom/service/spotify.disable
 Type=simple
 ExecStartPre=/opt/hifiberry/bin/bootmsg "Starting Vollibrespot"
 ExecStartPre=/opt/hifiberry/bin/store-volume /tmp/spotifyvol
-ExecStartPre=/opt/hifiberry/bin/set-host-ip ap-gew4.spotify.com 104.199.65.124
 ExecStart=/usr/bin/vollibrespot -c /etc/vollibrespot.conf
 ExecStartPost=sleep 1
 ExecStartPost=/opt/hifiberry/bin/restore-volume /tmp/spotifyvol


### PR DESCRIPTION
IP address seems to have changed and this now causes issues, I've no idea why it should be hardcoded in the first place but was done with commit: e2faba2925542995a9dc42e7e2a6e34b99a63af0

Feel free to just revert original commit instead!