### PR TITLE
Removed Spotify Service IP because it changed in the meantime

### DIFF
--- a/buildroot/package/spotifyd/spotify.service
+++ b/buildroot/package/spotifyd/spotify.service
@@ -12,7 +12,6 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 Environment=SPOTIFYD_CLIENT_ID=9223bb6a6d924c8da9b02519d03c987a
 ExecStartPre=/opt/hifiberry/bin/bootmsg "Starting Spotify"
 ExecStartPre=/opt/hifiberry/bin/store-volume /tmp/spotifyvol
-ExecStartPre=/opt/hifiberry/bin/set-host-ip ap-gew4.spotify.com 104.199.65.124
 ExecStart=/opt/hifiberry/bin/spotify-start
 ExecStartPost=sleep 1
 ExecStartPost=/opt/hifiberry/bin/restore-volume /tmp/spotifyvol

--- a/buildroot/package/vollibrespot/vollibrespot.conf
+++ b/buildroot/package/vollibrespot/vollibrespot.conf
@@ -28,3 +28,4 @@ backend = 'alsa'
 disable-audio-cache = true  # Cache audio files (relies on local system for cleanup!)
 cache-location = '/tmp'     # Path to cache
 metadata-port = 5030
+ap-port = 443


### PR DESCRIPTION
I removed the command for the static entry because obviously the IP address changed and that's the reason for an error and the not successfully connect with a Spotify Client.