### PR TITLE
fix: run nqptp as system service instead of user service

### DIFF
--- a/packages/shairport-sync/src/debian/postinst
+++ b/packages/shairport-sync/src/debian/postinst
@@ -6,10 +6,6 @@ if [ ! -d /var/lib/shairport ]; then
     mkdir -p /var/lib/shairport
 fi
 
-if [ ! -d /var/lib/nqptp ]; then
-    mkdir -p /var/lib/nqptp
-fi
-
 # Create shairport-sync group if it doesn't exist
 if ! getent group shairport-sync > /dev/null; then
     addgroup --system shairport-sync
@@ -21,22 +17,9 @@ if ! getent passwd shairport-sync > /dev/null; then
     usermod -a -G audio shairport-sync
 fi
 
-# Create nqptp group if it doesn't exist
-if ! getent group nqptp > /dev/null; then
-    addgroup --system nqptp
-fi
-
-# Create nqptp user if it doesn't exist
-if ! getent passwd nqptp > /dev/null; then
-    adduser --system --ingroup nqptp --home /var/lib/nqptp --no-create-home --shell /usr/sbin/nologin nqptp
-fi
-
 # Set ownership and permissions for directories after users are created
 chown shairport-sync:shairport-sync /var/lib/shairport
 chmod 755 /var/lib/shairport
-
-chown nqptp:nqptp /var/lib/nqptp
-chmod 755 /var/lib/nqptp
 
 # Add shairport-sync user to pipewire group for PipeWire integration
 if getent group pipewire > /dev/null; then

--- a/packages/shairport-sync/src/debian/rules
+++ b/packages/shairport-sync/src/debian/rules
@@ -86,7 +86,7 @@ override_dh_auto_install:
 	
 	# Install systemd user service files
 	install -D -m644 systemd/shairport.service $(CURDIR)/debian/hifiberry-shairport/usr/lib/systemd/user/shairport.service
-	install -D -m644 systemd/nqptp.service $(CURDIR)/debian/hifiberry-shairport/usr/lib/systemd/user/nqptp.service
+	install -D -m644 systemd/nqptp.service $(CURDIR)/debian/hifiberry-shairport/usr/lib/systemd/system/nqptp.service
 	
 	# Install NQPTP binary and man page
 	install -D -m755 nqptp/nqptp $(CURDIR)/debian/hifiberry-shairport/usr/bin/nqptp

--- a/packages/shairport-sync/src/start-nqptp.sh
+++ b/packages/shairport-sync/src/start-nqptp.sh
@@ -1,24 +1,8 @@
 #!/bin/bash
 #
-# start-nqptp.sh - NQPTP startup script with user validation
+# start-nqptp.sh - NQPTP startup script
 # This script handles startup of NQPTP daemon for network clock synchronization
 #
-
-# User validation check
-# Allow running as root, or as the user specified in /etc/hifiberry.user
-CURRENT_USER=$(whoami)
-if [ "$CURRENT_USER" != "root" ]; then
-    if [ -f "/etc/hifiberry.user" ]; then
-        AUTHORIZED_USER=$(cat /etc/hifiberry.user 2>/dev/null | tr -d '\n\r ')
-        if [ "$CURRENT_USER" != "$AUTHORIZED_USER" ]; then
-            echo "Error: not starting nqptp, this should run as user $AUTHORIZED_USER"
-            exit 0
-        fi
-    else
-        echo "Error: not starting nqptp, /etc/hifiberry.user not found and not running as root"
-        exit 0
-    fi
-fi
 
 # Start NQPTP with verbose output
 echo "Starting NQPTP daemon for network clock synchronization..."

--- a/packages/shairport-sync/src/systemd/nqptp.service
+++ b/packages/shairport-sync/src/systemd/nqptp.service
@@ -6,8 +6,9 @@ Wants=network.target
 
 [Service]
 Type=simple
-User=nqptp
 ExecStart=/usr/bin/start-nqptp
+DynamicUser=yes
+LimitRTPRIO=6
 Restart=on-failure
 RestartSec=5
 AmbientCapabilities=CAP_NET_BIND_SERVICE

--- a/packages/shairport-sync/src/systemd/nqptp.service
+++ b/packages/shairport-sync/src/systemd/nqptp.service
@@ -6,10 +6,11 @@ Wants=network.target
 
 [Service]
 Type=simple
+User=nqptp
 ExecStart=/usr/bin/start-nqptp
 Restart=on-failure
 RestartSec=5
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
nqptp requires CAP_NET_BIND_SERVICE to bind to ports 319 and 320 for
PTP-based timing, which AirPlay 2 depends on. It was incorrectly
installed as a systemd user service, causing it to fail immediately
with status=218/CAPABILITIES:

  Process: ExecStart=/usr/bin/start-nqptp
           (code=exited, status=218/CAPABILITIES)

This left shairport-sync unable to find the nqptp service, and it
would silently exit after its 10-second grace period (-g flag):

  *fatal error: Shairport Sync can not find the nqptp service on
  this system. Is nqptp installed and running?

With no AirPlay advertisement ever registered with Avahi, the device
was invisible to Apple clients despite shairport appearing to run.

The postinst script already correctly creates a dedicated nqptp system
user — this fix makes the service file and install location consistent
with that intent.
