### PR TITLE
Set default sink volume to 100%

### DIFF
--- a/packages/pipewire-configs/src/debian/hifiberry-pipewire-configs.install
+++ b/packages/pipewire-configs/src/debian/hifiberry-pipewire-configs.install
@@ -1,3 +1,4 @@
 etc/pipewire/pipewire.conf.d/99-hifiberry-headless.conf
+etc/xdg/wireplumber/wireplumber.conf.d/90-default-volume.conf
 etc/xdg/wireplumber/wireplumber.conf.d/91-hide-midi-ui.conf
 etc/xdg/wireplumber/wireplumber.conf.d/99-hifiberry-bluetooth.conf

--- a/packages/pipewire-configs/src/etc/xdg/wireplumber/wireplumber.conf.d/90-default-volume.conf
+++ b/packages/pipewire-configs/src/etc/xdg/wireplumber/wireplumber.conf.d/90-default-volume.conf
@@ -1,0 +1,7 @@
+# Set default sink volume to 100% instead of WirePlumber's default of 40%
+# Without this, new/unknown ALSA devices start at 0.40 (-24 dB cubic),
+# which noticeably reduces audio output.
+
+wireplumber.settings = {
+  device.routes.default-sink-volume = 1.0
+}


### PR DESCRIPTION
On a clean install, audio output is noticeably lower at max volume compared to builds from the master branch.

WirePlumber defaults `device.routes.default-sink-volume` to `0.40` (-24 dB) for new/unknown ALSA devices:

```
$ wpctl status
Audio
 ├─ Sinks:
 │      75. Built-in Audio Stereo               [vol: 0.40]
```

This can be verified and worked around with:

```
$ wpctl set-volume 75 1.0
```

This PR adds a WirePlumber config fragment to set the default to `1.0`.