### PR TITLE
Fix broken python3-pymcuprog / python3-pyedbglib packaging

### DIFF
--- a/packages/python-pyedbglib/src/debian/changelog
+++ b/packages/python-pyedbglib/src/debian/changelog
@@ -1,3 +1,12 @@
+python3-pyedbglib (2.24.2.18-2) stable; urgency=medium
+
+  * Fix package layout: install the inner pyedbglib/pyedbglib package instead of
+    the upstream repo root, which nested it as dist-packages/pyedbglib/pyedbglib
+    and broke "import pyedbglib" (import pyedbglib.hidtransport failed)
+  * Declare python3-serial runtime dependency (used by pyedbglib.serialport)
+
+ -- HiFiBerry <support@hifiberry.com>  Thu, 09 Jul 2026 08:34:31 +0100
+
 python3-pyedbglib (2.24.2.18-1) stable; urgency=medium
 
   * Updated to pyedbglib v2.24.2.18 from PyPI

--- a/packages/python-pyedbglib/src/debian/control
+++ b/packages/python-pyedbglib/src/debian/control
@@ -11,7 +11,8 @@ Vcs-Browser: https://github.com/hifiberry/hifiberry-os
 
 Package: python3-pyedbglib
 Architecture: all
-Depends: ${misc:Depends}
+Depends: ${misc:Depends},
+         python3-serial
 Description: Python library for EDBG communications
  This package provides a library and utilities for communicating with EDBG devices.
  EDBG is a family of on-board debuggers from Microchip for their development boards.

--- a/packages/python-pyedbglib/src/debian/rules
+++ b/packages/python-pyedbglib/src/debian/rules
@@ -4,9 +4,12 @@
 	dh $@
 
 override_dh_auto_install:
-	# Install the pyedbglib package
+	# Install the pyedbglib package. The upstream git checkout is a repo whose
+	# importable package lives one level down (pyedbglib/pyedbglib), so copy the
+	# inner directory - copying the repo root would nest it as
+	# dist-packages/pyedbglib/pyedbglib and break "import pyedbglib".
 	mkdir -p debian/python3-pyedbglib/usr/lib/python3/dist-packages/
-	cp -r pyedbglib debian/python3-pyedbglib/usr/lib/python3/dist-packages/
+	cp -r pyedbglib/pyedbglib debian/python3-pyedbglib/usr/lib/python3/dist-packages/
 
 override_dh_auto_test:
 	# Skip tests - no test suite provided

--- a/packages/python-pymcuprog/build.sh
+++ b/packages/python-pymcuprog/build.sh
@@ -8,7 +8,7 @@ _CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
 if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
 
 PACKAGE="python3-pymcuprog"
-VERSION="3.19.4.61-1"
+VERSION="3.19.4.61-2"
 
 # Check if DIST is set by environment variable
 if [ -n "$DIST" ]; then

--- a/packages/python-pymcuprog/src/debian/changelog
+++ b/packages/python-pymcuprog/src/debian/changelog
@@ -1,3 +1,16 @@
+python3-pymcuprog (3.19.4.61-2) stable; urgency=medium
+
+  * Declare missing runtime dependencies: python3-pyedbglib, python3-intelhex,
+    python3-platformdirs (the tool failed to import without them)
+  * Install a working /usr/bin/pymcuprog entry point (pymcuprog.pymcuprog:main);
+    the previous auto-generated wrapper imported a non-existent pymcuprog.main
+  * Port the appdirs import to platformdirs, which replaces appdirs in Debian
+    trixie (from appdirs import user_log_dir -> from platformdirs import ...)
+  * Fix PACKAGE_VERSION in debian/rules (was 3.17.3.45): the deb was versioned
+    3.19.4.61-1 but shipped 3.17.3.45 code
+
+ -- HiFiBerry <support@hifiberry.com>  Thu, 09 Jul 2026 08:34:31 +0100
+
 python3-pymcuprog (3.19.4.61-1) stable; urgency=medium
 
   * Updated to pymcuprog v3.19.4.61 from PyPI

--- a/packages/python-pymcuprog/src/debian/control
+++ b/packages/python-pymcuprog/src/debian/control
@@ -18,6 +18,9 @@ Vcs-Browser: https://github.com/hifiberry/hifiberry-os
 Package: python3-pymcuprog
 Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends},
+         python3-pyedbglib,
+         python3-intelhex,
+         python3-platformdirs,
          python3-serial,
          python3-yaml
 Description: Python MCU programming tool

--- a/packages/python-pymcuprog/src/debian/rules
+++ b/packages/python-pymcuprog/src/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
-# Configuration
-PACKAGE_VERSION = 3.17.3.45
+# Configuration - keep in sync with debian/changelog
+PACKAGE_VERSION = 3.19.4.61
 
 %:
 	dh $@
@@ -26,24 +26,23 @@ override_dh_auto_install:
 	# Install the unpacked wheel contents
 	mkdir -p debian/python3-pymcuprog/usr/lib/python3/dist-packages/
 	cp -r pymcuprog-source/* debian/python3-pymcuprog/usr/lib/python3/dist-packages/
-	# Install console scripts if they exist
-	if [ -d pymcuprog-source/../*/Scripts ]; then \
-		mkdir -p debian/python3-pymcuprog/usr/bin/; \
-		cp pymcuprog-source/../*/Scripts/* debian/python3-pymcuprog/usr/bin/ 2>/dev/null || true; \
-	fi
-	# Look for entry points and create console scripts
-	if [ -f pymcuprog-source/../*/METADATA ]; then \
-		grep -A10 "console_scripts" pymcuprog-source/../*/METADATA | grep "=" | while read line; do \
-			script_name=$$(echo "$$line" | cut -d'=' -f1 | tr -d ' '); \
-			if [ ! -z "$$script_name" ]; then \
-				echo "#!/usr/bin/python3" > debian/python3-pymcuprog/usr/bin/$$script_name; \
-				echo "import sys" >> debian/python3-pymcuprog/usr/bin/$$script_name; \
-				echo "from pymcuprog.main import main" >> debian/python3-pymcuprog/usr/bin/$$script_name; \
-				echo "sys.exit(main())" >> debian/python3-pymcuprog/usr/bin/$$script_name; \
-				chmod +x debian/python3-pymcuprog/usr/bin/$$script_name; \
-			fi \
-		done \
-	fi
+	# Debian trixie dropped python3-appdirs; the module was superseded by
+	# platformdirs (drop-in for the user_*_dir helpers pymcuprog uses). Rewrite
+	# the imports so the tool runs without the obsolete appdirs package.
+	find debian/python3-pymcuprog/usr/lib/python3/dist-packages/pymcuprog -name '*.py' \
+		-exec sed -i \
+			-e 's/^\(\s*\)from appdirs import/\1from platformdirs import/' \
+			-e 's/^\(\s*\)import appdirs\b/\1import platformdirs as appdirs/' {} +
+	# Install the console entry point. pymcuprog's CLI lives in
+	# pymcuprog/pymcuprog.py:main (upstream entry point pymcuprog.pymcuprog:main).
+	mkdir -p debian/python3-pymcuprog/usr/bin/
+	printf '%s\n' \
+		'#!/usr/bin/python3' \
+		'import sys' \
+		'from pymcuprog.pymcuprog import main' \
+		'sys.exit(main())' \
+		> debian/python3-pymcuprog/usr/bin/pymcuprog
+	chmod +x debian/python3-pymcuprog/usr/bin/pymcuprog
 
 override_dh_auto_test:
 	# Skip tests - requires hardware


### PR DESCRIPTION
Neither `python3-pymcuprog` nor `python3-pyedbglib` was usable as shipped: pymcuprog failed to import and had no working CLI, and pyedbglib was installed with a broken directory layout.

## pyedbglib
- **`debian/rules`** — was copying the whole upstream repo checkout into `dist-packages/pyedbglib/`, nesting the real package one level too deep at `dist-packages/pyedbglib/pyedbglib/`, so `import pyedbglib.hidtransport` failed. Now installs the inner `pyedbglib/pyedbglib` package.
- **`debian/control`** — declare the `python3-serial` runtime dependency (used by `pyedbglib.serialport`).

## pymcuprog
- **`debian/rules`** — `PACKAGE_VERSION` was `3.17.3.45`, so the deb was labelled `3.19.4.61-1` but shipped `3.17.3.45` code. Corrected to `3.19.4.61`.
- **`debian/rules`** — the auto-generated console script imported a non-existent `pymcuprog.main`; replaced with a working `/usr/bin/pymcuprog` → `pymcuprog.pymcuprog:main`.
- **`debian/rules`** — port `from appdirs import …` to `platformdirs` (appdirs was removed in Debian trixie).
- **`debian/control`** — declare the missing deps `python3-pyedbglib`, `python3-intelhex`, `python3-platformdirs`.

Both changelogs bumped to `-2` so the fix propagates via apt.

## Verification
Rebuilt both debs, inspected contents (deps / layout / CLI / version / appdirs patch all correct), purged the broken packages on a test CM5, clean-installed the new debs (no manual workarounds), and confirmed:

```
$ sudo pymcuprog ping -d attiny402 -t uart -u /dev/serial0
Connecting to SerialUPDI
Pinging device...
Ping response: 1E9227
Done.
```

(ATtiny402 on a HiFiBerry Studio DAC8x, over UPDI on the Pi serial pins.)