### PR TITLE
Enable mpd features (nfs and proxy support)

### DIFF
--- a/packages/mpd/src/debian/changelog
+++ b/packages/mpd/src/debian/changelog
@@ -1,3 +1,12 @@
+hifiberry-mpd (0.24.8.4) stable; urgency=low
+
+  * Enable NFS support (libnfs) and the proxy database plugin (libmpdclient)
+  * Request both meson features explicitly so a missing build dependency fails
+    the build instead of silently dropping the feature
+  * Thanks to Jose P. Ferrero for the report and patch
+
+ -- HiFiBerry <support@hifiberry.com>  Wed, 15 Jul 2026 09:00:00 +0000
+
 hifiberry-mpd (0.24.8.3) stable; urgency=low
 
   * Fix configure-mpd: re-copy default config when user config is empty (0 bytes)

--- a/packages/mpd/src/debian/control
+++ b/packages/mpd/src/debian/control
@@ -31,6 +31,8 @@ Build-Depends: debhelper-compat (= 13),
                libexpat1-dev,
                libavahi-client-dev,
                wget,
+               libmpdclient-dev,
+               libnfs-dev,
                ca-certificates
 Standards-Version: 4.6.0
 Homepage: https://www.musicpd.org/

--- a/packages/mpd/src/debian/rules
+++ b/packages/mpd/src/debian/rules
@@ -40,6 +40,8 @@ override_dh_auto_configure:
 		-Dlocal_socket=true \
 		-Dcue=true \
 		-Dzeroconf=avahi \
+		-Dnfs=enabled \
+		-Dlibmpdclient=enabled \
 		-Dpulse=disabled \
 		-Djack=disabled \
 		--prefix=/usr \


### PR DESCRIPTION
Included the following libraries:

libmpdclient-dev
libnfs-dev