### PR TITLE
mpd: update to upstream v0.24.13 (security)

### DIFF
--- a/packages/mpd/src/debian/changelog
+++ b/packages/mpd/src/debian/changelog
@@ -1,3 +1,17 @@
+hifiberry-mpd (0.24.13.1) stable; urgency=high
+
+  * Updated to MPD v0.24.13 from upstream
+  * Security: v0.24.11 fixes a path traversal that let clients escape the
+    music directory via "listfiles ..". This was reachable without a password
+    on our default configuration, which binds to 0.0.0.0 and grants
+    default_permissions "read,add,control" (listfiles only needs read).
+  * Security: v0.24.11 fixes a stack buffer overflow in the pcm decoder and
+    disallows newlines and invalid UTF-8 in song URIs
+  * v0.24.13 fixes a pipewire file descriptor leak after connect failure
+  * v0.24.12 fixes a v0.24.11 regression with empty URIs in "lsinfo"/"add"
+
+ -- HiFiBerry <support@hifiberry.com>  Wed, 15 Jul 2026 12:00:00 +0000
+
 hifiberry-mpd (0.24.8.4) stable; urgency=low
 
   * Enable NFS support (libnfs) and the proxy database plugin (libmpdclient)

--- a/packages/mpd/src/debian/rules
+++ b/packages/mpd/src/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 # Configuration
-MPD_VERSION = 0.24.8
+MPD_VERSION = 0.24.13
 MPC_VERSION = 0.35
 
 %:


### PR DESCRIPTION
Bumps the packaged MPD from **0.24.8 to 0.24.13** (upstream released 2026-07-10). This is only the `MPD_VERSION` pin in `debian/rules` plus a changelog entry — every meson option we pass still exists unchanged upstream.

## Why this matters

Upstream **0.24.11** fixed a path traversal (reported by Matteo Strada and Daniele Berardinelli, [MPD#2484](https://github.com/MusicPlayerDaemon/MPD/issues/2484)) that let a client escape `music_directory` with `listfiles ..`. **This was reachable without a password on our shipped default config**, which binds MPD to `0.0.0.0:6600` and sets `default_permissions "read,add,control"` — and `listfiles` only needs `read`.

Also in 0.24.11: a stack buffer overflow in the pcm decoder ([MPD#2485](https://github.com/MusicPlayerDaemon/MPD/issues/2485)) and tighter URI validation (no newlines / invalid UTF-8 in song URIs). 0.24.13 additionally fixes a **PipeWire file-descriptor leak after connect failure**, relevant on a PipeWire-based OS. 0.24.12 fixes a 0.24.11 regression with empty URIs in `lsinfo`/`add`.

## Verification

Full `sbuild` on arm64, `Status: successful`. meson resolved libnfs 5.0.2 and libmpdclient 2.22; resulting deb is `0.24.13.1` and keeps the nfs/proxy features from #616.

Installed on a real HiFiBerryOS device (arm64) running the vulnerable default config and reproduced the fix end to end:

- **Before (0.24.8.3):** `listfiles ".."` (no password) returned the parent of the music directory.
- **After (0.24.13.1):** same command returns `ACK [2@0] {listfiles} Bad relative path`; legitimate `listfiles` still works; playback state intact; service starts cleanly.