### PR TITLE
fix(pipewire-configs): disable S/PDIF capture on Digi cards

### DIFF
--- a/packages/pipewire-configs/src/debian/changelog
+++ b/packages/pipewire-configs/src/debian/changelog
@@ -1,3 +1,10 @@
+hifiberry-pipewire-configs (1.0.9) stable; urgency=medium
+
+  * Add 10-hifiberry-rates.conf: allow 44.1-192kHz so the graph follows the
+    source rate instead of resampling everything to 48kHz
+
+ -- HiFiBerry <support@hifiberry.com>  Wed, 15 Jul 2026 10:00:00 +0200
+
 hifiberry-pipewire-configs (1.0.8) stable; urgency=medium
 
   * Depend on hifiberry-input-processor (renamed from ladspa-riaa)

--- a/packages/pipewire-configs/src/debian/changelog
+++ b/packages/pipewire-configs/src/debian/changelog
@@ -1,3 +1,14 @@
+hifiberry-pipewire-configs (1.0.10) stable; urgency=medium
+
+  * Add 98-hifiberry-digi-no-capture.conf: disable the S/PDIF capture node on
+    HiFiBerry Digi cards (snd_rpi_hifiberry_digi / WM8804). The Digi's receiver
+    and transmitter share one clock domain, so exposing the input to PipeWire
+    lets it open the S/PDIF RX and slave the card clock to the (absent) input,
+    breaking or locking playback (e.g. stuck at 192 kHz). Digi is an output
+    card; its capture must not be connected to PipeWire.
+
+ -- HiFiBerry <support@hifiberry.com>  Thu, 16 Jul 2026 12:00:00 +0200
+
 hifiberry-pipewire-configs (1.0.9) stable; urgency=medium
 
   * Add 10-hifiberry-rates.conf: allow 44.1-192kHz so the graph follows the

--- a/packages/pipewire-configs/src/debian/hifiberry-pipewire-configs.install
+++ b/packages/pipewire-configs/src/debian/hifiberry-pipewire-configs.install
@@ -3,3 +3,4 @@ etc/xdg/wireplumber/wireplumber.conf.d/90-default-volume.conf
 etc/xdg/wireplumber/wireplumber.conf.d/91-hide-midi-ui.conf
 etc/xdg/wireplumber/wireplumber.conf.d/99-hifiberry-bluetooth.conf
 etc/pipewire/pipewire.conf.d/10-hifiberry-rates.conf
+etc/xdg/wireplumber/wireplumber.conf.d/98-hifiberry-digi-no-capture.conf

--- a/packages/pipewire-configs/src/debian/hifiberry-pipewire-configs.install
+++ b/packages/pipewire-configs/src/debian/hifiberry-pipewire-configs.install
@@ -2,3 +2,4 @@ etc/pipewire/pipewire.conf.d/99-hifiberry-headless.conf
 etc/xdg/wireplumber/wireplumber.conf.d/90-default-volume.conf
 etc/xdg/wireplumber/wireplumber.conf.d/91-hide-midi-ui.conf
 etc/xdg/wireplumber/wireplumber.conf.d/99-hifiberry-bluetooth.conf
+etc/pipewire/pipewire.conf.d/10-hifiberry-rates.conf

--- a/packages/pipewire-configs/src/etc/pipewire/pipewire.conf.d/10-hifiberry-rates.conf
+++ b/packages/pipewire-configs/src/etc/pipewire/pipewire.conf.d/10-hifiberry-rates.conf
@@ -1,0 +1,13 @@
+# HiFiBerry PipeWire rate policy
+#
+# Without allowed-rates the graph is pinned to 48kHz and every source is
+# resampled -- including 44.1kHz content and 192kHz USB gadget audio.
+# Listing rates lets the graph follow the source instead.
+#
+# PipeWire clamps to what the card actually supports, so a DAC that cannot do
+# 192kHz simply will not switch that high.
+
+context.properties = {
+    default.clock.rate          = 48000
+    default.clock.allowed-rates = [ 44100 48000 88200 96000 176400 192000 ]
+}

--- a/packages/pipewire-configs/src/etc/xdg/wireplumber/wireplumber.conf.d/98-hifiberry-digi-no-capture.conf
+++ b/packages/pipewire-configs/src/etc/xdg/wireplumber/wireplumber.conf.d/98-hifiberry-digi-no-capture.conf
@@ -1,0 +1,22 @@
+# HiFiBerry Digi (WM8804) shares one clock domain between S/PDIF in and out.
+# Exposing the capture to PipeWire lets it open the S/PDIF receiver, which
+# slaves the card clock to the (absent) input and breaks/locks playback
+# (e.g. stuck at 192 kHz). The Digi is an output card: disable its capture node.
+#
+# Covers all Digi variants (Digi+, Digi+ Pro, Digi2 Pro) — they share the
+# snd_rpi_hifiberry_digi driver.
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        alsa.card_name = "snd_rpi_hifiberry_digi"
+        api.alsa.pcm.stream = "capture"
+      }
+    ]
+    actions = {
+      update-props = {
+        node.disabled = true
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Problem

On HiFiBerry **Digi** cards (WM8804), the S/PDIF receiver and transmitter share a single clock domain — the input cannot run at a different sample rate than the output. WirePlumber's analog-input autoconnect rule (`~alsa_input.platform-soc_.*` → `input-processor`) and the vu-meter service both auto-open the Digi's S/PDIF **capture**, which slaves the card clock to the (absent) input and breaks/locks playback — users see it stuck at 192 kHz with no sound.

Reported on the forum (Digi+ Pro): https://support.hifiberry.com/forum/c/hifiberry-digi/10857

## Fix

`98-hifiberry-digi-no-capture.conf`: a WirePlumber 0.5 `monitor.alsa.rules` drop-in that disables **only** the capture node on `snd_rpi_hifiberry_digi` (covers Digi+, Digi+ Pro, Digi2 Pro), leaving the output untouched. With no capture node, neither the autoconnect rule nor vu-meter can open the S/PDIF receiver.

## Verification

Reproduced and fixed on real Digi+ hardware (CM5):
- Before: Digi S/PDIF capture auto-linked into `input-processor` **and** `vu-meter`; capture PCM `RUNNING` (RX held open) unsolicited.
- After: no capture source node; PCM `closed`; playback verified at **44.1 kHz and 192 kHz**; vu-meter falls back to the sink monitor.

Bumps `hifiberry-pipewire-configs` to **1.0.10** (includes the 1.0.9 rate-range change). The 1.0.10 deb is already built and published to the mirror.

## Commits
- `feat(pipewire-configs): allow 44.1-192kHz rates` (1.0.9)
- `fix(pipewire-configs): disable S/PDIF capture on Digi cards` (1.0.10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)