### PR TITLE
mpd: delete the user mpd.socket — socket activation silently disables zeroconf

### DIFF
--- a/packages/mpd/src/debian/changelog
+++ b/packages/mpd/src/debian/changelog
@@ -1,3 +1,16 @@
+hifiberry-mpd (0.24.13.4) stable; urgency=medium
+
+  * Stop shipping the upstream user mpd.socket. Its postinst enabled it, so
+    MPD started socket-activated; on that path listen_global_init() returns
+    before setting listen_port, ZeroconfInit() logs "No global port, disabling
+    zeroconf" and _mpd._tcp is never advertised despite zeroconf_enabled "yes".
+  * Clean up the enable state that socket left behind on upgrade: the new
+    maintainer scripts no longer mention mpd.socket, so the .wants symlink and
+    the deb-systemd-helper state file would survive as dangling leftovers, and
+    a socket still loaded in the user manager would keep holding port 6600.
+
+ -- HiFiBerry <support@hifiberry.com>  Thu, 06 Aug 2026 16:30:00 +0200
+
 hifiberry-mpd (0.24.13.3) stable; urgency=medium
 
   * Add Breaks: hifiberry-audiocontrol (<< 0.8.8). Older audiocontrol still

--- a/packages/mpd/src/debian/postinst
+++ b/packages/mpd/src/debian/postinst
@@ -12,6 +12,47 @@ case "$1" in
         # Set group ownership to audio and make directories group-writable
         chgrp audio /var/lib/mpd /var/lib/mpd/music /var/lib/mpd/playlists
         chmod g+rwx /var/lib/mpd /var/lib/mpd/music /var/lib/mpd/playlists
+
+        # Versions up to 0.24.13.3 shipped /usr/lib/systemd/user/mpd.socket and
+        # enabled it, which made MPD start socket-activated and silently disabled
+        # zeroconf. The unit is no longer shipped, but the enable state it left
+        # behind is not cleaned up by anything: the new maintainer scripts no
+        # longer mention mpd.socket, so the .wants symlink and the helper state
+        # file survive the upgrade as dangling leftovers, and a socket still
+        # loaded in the running user manager keeps holding port 6600.
+        if command -v deb-systemd-helper >/dev/null 2>&1; then
+            # purge works from the helper's own state file, so it still removes
+            # the symlinks even though the unit file itself is already gone.
+            deb-systemd-helper --user purge 'mpd.socket' >/dev/null 2>&1 || true
+            deb-systemd-helper --user unmask 'mpd.socket' >/dev/null 2>&1 || true
+        fi
+        rm -f /etc/systemd/user/sockets.target.wants/mpd.socket || true
+
+        # Drop it from the live session too, otherwise MPD cannot bind 6600
+        # until the next reboot. Best effort; no-op during image builds.
+        if [ -d /run/systemd/system ]; then
+            HB_USER=""
+            if [ -f /etc/hifiberry.user ]; then
+                HB_USER=$(grep -vE '^[[:space:]]*#|^[[:space:]]*$' /etc/hifiberry.user | head -1 | tr -d '[:space:]')
+            fi
+            if [ -n "$HB_USER" ] && getent passwd "$HB_USER" >/dev/null 2>&1; then
+                HB_UID=$(id -u "$HB_USER" 2>/dev/null)
+                if [ -n "$HB_UID" ] && [ -d "/run/user/$HB_UID" ]; then
+                    systemd-run --uid "$HB_UID" --setenv XDG_RUNTIME_DIR="/run/user/$HB_UID" \
+                        --pipe --wait --quiet --collect \
+                        systemctl --user stop mpd.socket >/dev/null 2>&1 || true
+                    systemd-run --uid "$HB_UID" --setenv XDG_RUNTIME_DIR="/run/user/$HB_UID" \
+                        --pipe --wait --quiet --collect \
+                        systemctl --user daemon-reload >/dev/null 2>&1 || true
+                    # An already socket-activated MPD keeps its inherited fd (and
+                    # its disabled zeroconf) until it restarts. try-restart, so a
+                    # deliberately stopped MPD is not started by an upgrade.
+                    systemd-run --uid "$HB_UID" --setenv XDG_RUNTIME_DIR="/run/user/$HB_UID" \
+                        --pipe --wait --quiet --collect \
+                        systemctl --user try-restart mpd.service >/dev/null 2>&1 || true
+                fi
+            fi
+        fi
         ;;
     abort-upgrade|abort-remove|abort-deconfigure)
         :

--- a/packages/mpd/src/debian/postrm
+++ b/packages/mpd/src/debian/postrm
@@ -6,8 +6,9 @@ case "$1" in
         # Remove directories on purge (but preserve music and playlists)
         rm -rf /run/mpd || true
         # Note: We don't remove /var/lib/mpd as it may contain user data
-    # Clean up any leftover system socket symlink from previous versions
+    # Clean up any leftover socket symlinks from versions that shipped them
     rm -f /etc/systemd/system/sockets.target.wants/mpd.socket || true
+    rm -f /etc/systemd/user/sockets.target.wants/mpd.socket || true
         ;;
     
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/packages/mpd/src/debian/rules
+++ b/packages/mpd/src/debian/rules
@@ -68,8 +68,13 @@ override_dh_auto_install:
 	# Remove the automatically installed service files
 	rm -f debian/hifiberry-mpd/usr/lib/systemd/system/mpd.service || true
 	rm -f debian/hifiberry-mpd/usr/lib/systemd/user/mpd.service || true
-	# Remove socket activation and templated units we don't use
+	# Remove socket activation and templated units we don't use.
+	# The user socket matters: if it survives, its postinst enables it and MPD
+	# starts socket-activated, which makes listen_global_init() return before
+	# setting listen_port -- so ZeroconfInit() bails with "No global port,
+	# disabling zeroconf" and _mpd._tcp is never advertised.
 	rm -f debian/hifiberry-mpd/usr/lib/systemd/system/mpd.socket || true
+	rm -f debian/hifiberry-mpd/usr/lib/systemd/user/mpd.socket || true
 	rm -f debian/hifiberry-mpd/usr/lib/systemd/system/mpd@.service || true
 
 	# Install our custom systemd user service file


### PR DESCRIPTION
`hifiberry-mpd` ships `/usr/lib/systemd/user/mpd.socket` and its postinst enables it (`deb-systemd-helper --user enable 'mpd.socket'`). The socket does `ListenStream=6600`, so MPD starts socket-activated — and MPD disables Zeroconf on that path:

`src/Listen.cxx`, `listen_global_init()`:

```c
int port = config.GetPositive(ConfigOption::PORT, DEFAULT_PORT);
#ifdef ENABLE_SYSTEMD_DAEMON
        if (listen_systemd_activation(listener))
                return;          // returns BEFORE listen_port = port
#endif
        ...
        listen_port = port;
```

`src/zeroconf/Glue.cxx`, `ZeroconfInit()` then hits `listen_port <= 0` and returns null, logging `zeroconf: No global port, disabling zeroconf`.

Result: `_mpd._tcp` is never advertised, on any HiFiBerryOS device, despite `/usr/share/mpd/mpd.conf` shipping `zeroconf_enabled "yes"`. MPD is otherwise healthy — 6600 answers normally — so the failure is invisible without an mDNS browse.

Observed on hifiberry-mpd 0.24.13.3 (Trixie, arm64, Pi 4):

```
$ systemctl --user is-enabled mpd.socket
enabled
$ systemctl --user is-active mpd.socket
active
$ journalctl --user -u mpd -b | grep -i zeroconf
zeroconf: No global port, disabling zeroconf
$ systemctl is-active avahi-daemon
active
$ dns-sd -B _mpd._tcp
(nothing)
```

`_airplay._tcp` and `_spotify-connect._tcp` advertise fine on the same devices, so Avahi itself is working.

`debian/rules` already removes the system socket and both `mpd.service` files, but not the user socket:

```
rm -f debian/hifiberry-mpd/usr/lib/systemd/system/mpd.service || true
rm -f debian/hifiberry-mpd/usr/lib/systemd/user/mpd.service || true
rm -f debian/hifiberry-mpd/usr/lib/systemd/system/mpd.socket || true
rm -f debian/hifiberry-mpd/usr/lib/systemd/system/mpd@.service || true
```

Nothing in the package appears to want socket activation — `mpd.service` is `Type=simple` with `ExecStart=/usr/bin/start-mpd`. Suggested fix, alongside the existing removals:

```
rm -f debian/hifiberry-mpd/usr/lib/systemd/user/mpd.socket || true
```

Masking the user socket locally confirms it: MPD binds 6600 itself, the warning disappears, and `_mpd._tcp` is advertised.
