### PR TITLE
mpd: announce the pretty hostname over Zeroconf, like shairport and librespot

### DIFF
--- a/packages/mpd/src/configure-mpd.py
+++ b/packages/mpd/src/configure-mpd.py
@@ -13,45 +13,63 @@ import subprocess
 import re
 from pathlib import Path
 
+# Import configurator modules. Unlike configure-raat, a missing configurator is
+# not fatal here: it only costs us the announced name, and MPD should still
+# start, so we fall back instead of exiting.
+try:
+    from configurator.hostname_utils import get_hostnames_with_fallback
+except ImportError as e:
+    print(f"Warning: Could not import configurator hostname utils: {e}")
+    get_hostnames_with_fallback = None
+
 USER_ETC = Path.home() / "etc"
 USER_CONFIG = USER_ETC / "mpd.conf"
 DEFAULT_CONFIG_SRC = Path("/usr/share/mpd/mpd.conf")
-
-# hostnamectl is a D-Bus round-trip to systemd-hostnamed and this runs
-# synchronously before `exec mpd`. If hostnamed is wedged an unbounded call
-# would hang mpd.service in "activating" forever, so bound it.
-HOSTNAMECTL_TIMEOUT = 5
 
 # Avahi's service-name label is capped at 63 bytes. The hostname API accepts up
 # to 64 characters, so a long name -- or a shorter one with multi-byte
 # characters -- would make registration fail and MPD vanish from Zeroconf.
 ZEROCONF_NAME_MAX_BYTES = 63
 
+# A device with no pretty hostname set typically reports the default system
+# hostname, which isn't a name anyone wants announced on the network.
+UNSET_HOSTNAMES = ("", "localhost")
+
+DEFAULT_NAME = "HiFiBerry"
+
 
 def get_pretty_hostname():
     """Get the pretty hostname, falling back to the hostname, then "HiFiBerry".
 
-    Same order start-shairport.sh, start-librespot.sh and start-squeezelite use
-    for the name they announce, so all four players show up under one name. Like
-    start-squeezelite, a literal "localhost" counts as unset.
-    """
-    try:
-        result = subprocess.run(['hostnamectl', 'hostname', '--pretty'],
-                                capture_output=True, text=True,
-                                timeout=HOSTNAMECTL_TIMEOUT)
-        name = result.stdout.strip()
-        if result.returncode == 0 and name and name != "localhost":
-            return name
-    except Exception as e:
-        print(f"Warning: Could not read pretty hostname: {e}")
+    The hostnamectl calls come from configurator.hostname_utils (already a
+    dependency), which bounds them with a timeout -- this runs synchronously
+    before `exec mpd`, so an unbounded D-Bus round-trip to a wedged
+    systemd-hostnamed would hang mpd.service in "activating" forever.
 
-    # socket.gethostname() can't hang and needs no error handling, unlike the
-    # `hostname` subprocess the other wrappers shell out to.
+    The helper stops one step short of what the players need, though: it falls
+    pretty -> hostname and then returns None, with no "HiFiBerry" default, and
+    it treats a literal "localhost" as a real name. Both are applied here so
+    MPD announces what start-shairport.sh, start-librespot.sh and
+    start-squeezelite announce, rather than "localhost" or nothing.
+    """
+    hostname = pretty_hostname = None
+    if get_hostnames_with_fallback is not None:
+        try:
+            hostname, pretty_hostname = get_hostnames_with_fallback()
+        except Exception as e:
+            print(f"Warning: Could not read hostnames from configurator: {e}")
+
+    for name in (pretty_hostname, hostname):
+        if name and name.strip().lower() not in UNSET_HOSTNAMES:
+            return name.strip()
+
+    # Last resort if the configurator import or both hostnamectl calls failed.
+    # socket.gethostname() can't hang and needs no error handling.
     name = socket.gethostname().strip()
-    if name and name != "localhost":
+    if name and name.lower() not in UNSET_HOSTNAMES:
         return name
 
-    return "HiFiBerry"
+    return DEFAULT_NAME
 
 
 def truncate_to_bytes(name, limit=ZEROCONF_NAME_MAX_BYTES):

--- a/packages/mpd/src/configure-mpd.py
+++ b/packages/mpd/src/configure-mpd.py
@@ -6,6 +6,7 @@ its audio_output mixer settings based on detected hardware.
 """
 
 import os
+import socket
 import sys
 import shutil
 import subprocess
@@ -16,64 +17,59 @@ USER_ETC = Path.home() / "etc"
 USER_CONFIG = USER_ETC / "mpd.conf"
 DEFAULT_CONFIG_SRC = Path("/usr/share/mpd/mpd.conf")
 
+# hostnamectl is a D-Bus round-trip to systemd-hostnamed and this runs
+# synchronously before `exec mpd`. If hostnamed is wedged an unbounded call
+# would hang mpd.service in "activating" forever, so bound it.
+HOSTNAMECTL_TIMEOUT = 5
+
+# Avahi's service-name label is capped at 63 bytes. The hostname API accepts up
+# to 64 characters, so a long name -- or a shorter one with multi-byte
+# characters -- would make registration fail and MPD vanish from Zeroconf.
+ZEROCONF_NAME_MAX_BYTES = 63
+
+
 def get_pretty_hostname():
     """Get the pretty hostname, falling back to the hostname, then "HiFiBerry".
 
-    Same order start-shairport.sh and start-librespot.sh use for the name they
-    announce, so all three players show up under one name.
+    Same order start-shairport.sh, start-librespot.sh and start-squeezelite use
+    for the name they announce, so all four players show up under one name. Like
+    start-squeezelite, a literal "localhost" counts as unset.
     """
     try:
         result = subprocess.run(['hostnamectl', 'hostname', '--pretty'],
-                                capture_output=True, text=True)
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
+                                capture_output=True, text=True,
+                                timeout=HOSTNAMECTL_TIMEOUT)
+        name = result.stdout.strip()
+        if result.returncode == 0 and name and name != "localhost":
+            return name
     except Exception as e:
         print(f"Warning: Could not read pretty hostname: {e}")
 
-    try:
-        result = subprocess.run(['hostname'], capture_output=True, text=True)
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except Exception as e:
-        print(f"Warning: Could not read hostname: {e}")
+    # socket.gethostname() can't hang and needs no error handling, unlike the
+    # `hostname` subprocess the other wrappers shell out to.
+    name = socket.gethostname().strip()
+    if name and name != "localhost":
+        return name
 
     return "HiFiBerry"
 
 
-def update_zeroconf_name(config_path, name):
-    """Set zeroconf_name in the MPD config, leaving every other line untouched."""
+def truncate_to_bytes(name, limit=ZEROCONF_NAME_MAX_BYTES):
+    """Truncate a name to `limit` UTF-8 bytes without splitting a character."""
+    encoded = name.encode('utf-8')
+    if len(encoded) <= limit:
+        return name
+    truncated = encoded[:limit].decode('utf-8', errors='ignore')
+    print(f"Warning: Zeroconf name too long for mDNS, truncated to: {truncated}")
+    return truncated
+
+
+def format_zeroconf_name(name):
+    """Render the canonical zeroconf_name line for the given name."""
     # MPD's config tokenizer treats \ as an escape inside a quoted string, so a
     # name containing " or \ has to be escaped or the value is truncated/broken.
-    escaped = name.replace('\\', '\\\\').replace('"', '\\"')
-    try:
-        with open(config_path, 'r') as f:
-            lines = f.readlines()
-    except Exception as e:
-        print(f"Warning: Could not read {config_path} to set zeroconf_name: {e}")
-        return
-
-    out = []
-    replaced = False
-    for line in lines:
-        if line.strip().split()[:1] == ['zeroconf_name']:
-            if not replaced:
-                out.append(f'zeroconf_name\t\t"{escaped}"\n')
-                replaced = True
-            continue
-        out.append(line)
-
-    if not replaced:
-        # No zeroconf_name in the config (e.g. a hand-edited one): add it.
-        if out and not out[-1].endswith('\n'):
-            out[-1] += '\n'
-        out.append(f'zeroconf_name\t\t"{escaped}"\n')
-
-    try:
-        with open(config_path, 'w') as f:
-            f.writelines(out)
-        print(f"Zeroconf name set to: {name}")
-    except Exception as e:
-        print(f"Warning: Could not write zeroconf_name to {config_path}: {e}")
+    escaped = truncate_to_bytes(name).replace('\\', '\\\\').replace('"', '\\"')
+    return f'zeroconf_name\t\t"{escaped}"\n'
 
 
 def get_hw_mixer_info():
@@ -242,8 +238,13 @@ def manage_music_symlinks(music_dir, samba_dirs):
         except Exception as e:
             print(f"Warning: Could not create symlink {symlink_path}: {e}")
 
-def update_mpd_config_in_place(config_path, mixer_info):
-    """Update MPD configuration with mixer settings in-place for user file."""
+def update_mpd_config_in_place(config_path, mixer_info, zeroconf_name=None):
+    """Update MPD configuration in-place for user file.
+
+    Rewrites the audio_output mixer settings, and -- when zeroconf_name is given
+    -- the top-level zeroconf_name. Both are managed keys: existing lines are
+    dropped and the canonical form re-emitted.
+    """
     try:
         with open(config_path, 'r') as f:
             config_lines = f.readlines()
@@ -258,6 +259,7 @@ def update_mpd_config_in_place(config_path, mixer_info):
     in_audio_output = False
     audio_output_depth = 0
     mixer_lines_added = False
+    zeroconf_line_added = False
 
     for line in config_lines:
         stripped = line.strip()
@@ -292,7 +294,23 @@ def update_mpd_config_in_place(config_path, mixer_info):
                                  stripped.startswith('mixer_index')):
             continue
 
+        # zeroconf_name is a top-level key; only drop it outside a block, so a
+        # stray copy nested in audio_output is left alone rather than becoming
+        # the line we re-emit (MPD rejects it there as an unknown parameter).
+        if zeroconf_name is not None and not in_audio_output and \
+                stripped.split()[:1] == ['zeroconf_name']:
+            if not zeroconf_line_added:
+                output_lines.append(format_zeroconf_name(zeroconf_name))
+                zeroconf_line_added = True
+            continue
+
         output_lines.append(line)
+
+    if zeroconf_name is not None and not zeroconf_line_added:
+        # No top-level zeroconf_name (e.g. a hand-edited config): append it.
+        if output_lines and not output_lines[-1].endswith('\n'):
+            output_lines[-1] += '\n'
+        output_lines.append(format_zeroconf_name(zeroconf_name))
 
     try:
         Path(config_path).parent.mkdir(parents=True, exist_ok=True)
@@ -300,11 +318,23 @@ def update_mpd_config_in_place(config_path, mixer_info):
             shutil.copy2(config_path, str(config_path) + ".bak")
         except Exception:
             pass
-        with open(config_path, 'w') as f:
+        # Write via a temp file and rename. A truncating in-place write that dies
+        # partway (full SD card, killed mid-restart) would leave a config cut off
+        # mid-line that start-mpd.sh then execs mpd on -- and the self-heal in
+        # main() only catches a zero-length file, so it would survive reboots.
+        tmp_path = str(config_path) + ".tmp"
+        with open(tmp_path, 'w') as f:
             f.writelines(output_lines)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, config_path)
         print(f"MPD configuration updated: {config_path}")
     except Exception as e:
         print(f"Error writing configuration file: {e}")
+        try:
+            os.unlink(str(config_path) + ".tmp")
+        except Exception:
+            pass
         sys.exit(1)
 
 def main():
@@ -326,12 +356,15 @@ def main():
     if mixer_info["mixer_type"] == "hardware":
         print(f"Hardware mixer: {mixer_info['mixer_control']} on {mixer_info['mixer_device']}")
 
-    update_mpd_config_in_place(USER_CONFIG, mixer_info)
+    # Announce the same name as the other players (shairport, librespot,
+    # squeezelite), which all read the pretty hostname at startup. MPD takes its
+    # Zeroconf name from the config file only, so it has to be written here on
+    # every start -- folded into the mixer pass so the config is read and
+    # rewritten once.
+    zeroconf_name = get_pretty_hostname()
+    print(f"Zeroconf name: {zeroconf_name}")
 
-    # Announce the same name as the other players (shairport, librespot), which
-    # both read the pretty hostname at startup. MPD takes its Zeroconf name from
-    # the config file only, so it has to be written here on every start.
-    update_zeroconf_name(USER_CONFIG, get_pretty_hostname())
+    update_mpd_config_in_place(USER_CONFIG, mixer_info, zeroconf_name)
 
     print("Managing music directory symlinks...")
     music_dir = parse_music_directory(USER_CONFIG)

--- a/packages/mpd/src/configure-mpd.py
+++ b/packages/mpd/src/configure-mpd.py
@@ -16,6 +16,66 @@ USER_ETC = Path.home() / "etc"
 USER_CONFIG = USER_ETC / "mpd.conf"
 DEFAULT_CONFIG_SRC = Path("/usr/share/mpd/mpd.conf")
 
+def get_pretty_hostname():
+    """Get the pretty hostname, falling back to the hostname, then "HiFiBerry".
+
+    Same order start-shairport.sh and start-librespot.sh use for the name they
+    announce, so all three players show up under one name.
+    """
+    try:
+        result = subprocess.run(['hostnamectl', 'hostname', '--pretty'],
+                                capture_output=True, text=True)
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception as e:
+        print(f"Warning: Could not read pretty hostname: {e}")
+
+    try:
+        result = subprocess.run(['hostname'], capture_output=True, text=True)
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception as e:
+        print(f"Warning: Could not read hostname: {e}")
+
+    return "HiFiBerry"
+
+
+def update_zeroconf_name(config_path, name):
+    """Set zeroconf_name in the MPD config, leaving every other line untouched."""
+    # MPD's config tokenizer treats \ as an escape inside a quoted string, so a
+    # name containing " or \ has to be escaped or the value is truncated/broken.
+    escaped = name.replace('\\', '\\\\').replace('"', '\\"')
+    try:
+        with open(config_path, 'r') as f:
+            lines = f.readlines()
+    except Exception as e:
+        print(f"Warning: Could not read {config_path} to set zeroconf_name: {e}")
+        return
+
+    out = []
+    replaced = False
+    for line in lines:
+        if line.strip().split()[:1] == ['zeroconf_name']:
+            if not replaced:
+                out.append(f'zeroconf_name\t\t"{escaped}"\n')
+                replaced = True
+            continue
+        out.append(line)
+
+    if not replaced:
+        # No zeroconf_name in the config (e.g. a hand-edited one): add it.
+        if out and not out[-1].endswith('\n'):
+            out[-1] += '\n'
+        out.append(f'zeroconf_name\t\t"{escaped}"\n')
+
+    try:
+        with open(config_path, 'w') as f:
+            f.writelines(out)
+        print(f"Zeroconf name set to: {name}")
+    except Exception as e:
+        print(f"Warning: Could not write zeroconf_name to {config_path}: {e}")
+
+
 def get_hw_mixer_info():
     """Get hardware mixer information using config-soundcard"""
     try:
@@ -267,6 +327,11 @@ def main():
         print(f"Hardware mixer: {mixer_info['mixer_control']} on {mixer_info['mixer_device']}")
 
     update_mpd_config_in_place(USER_CONFIG, mixer_info)
+
+    # Announce the same name as the other players (shairport, librespot), which
+    # both read the pretty hostname at startup. MPD takes its Zeroconf name from
+    # the config file only, so it has to be written here on every start.
+    update_zeroconf_name(USER_CONFIG, get_pretty_hostname())
 
     print("Managing music directory symlinks...")
     music_dir = parse_music_directory(USER_CONFIG)

--- a/packages/mpd/src/debian/changelog
+++ b/packages/mpd/src/debian/changelog
@@ -8,7 +8,14 @@ hifiberry-mpd (0.24.13.5) stable; urgency=medium
     different names, and on a multi-device setup every MPD looked identical.
     configure-mpd now writes zeroconf_name on each start, using the same
     fallback order. Names containing " or \ are escaped for MPD's config
-    tokenizer.
+    tokenizer, and the name is truncated to 63 bytes on a character boundary
+    to stay within Avahi's service-name limit.
+  * NOTE: zeroconf_name in ~/etc/mpd.conf is now managed by configure-mpd and
+    is overwritten on every MPD start. It previously passed through verbatim
+    and survived restarts; a hand-set name there will now be replaced by the
+    pretty hostname. Set the device name via the hostname API (or
+    `hostnamectl set-hostname --pretty`) instead, which renames MPD, AirPlay
+    and Spotify Connect together.
 
  -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 10:00:00 +0200
 

--- a/packages/mpd/src/debian/changelog
+++ b/packages/mpd/src/debian/changelog
@@ -1,3 +1,17 @@
+hifiberry-mpd (0.24.13.5) stable; urgency=medium
+
+  * Announce the pretty hostname over Zeroconf, like the other players.
+    start-shairport.sh and start-librespot.sh both read `hostnamectl hostname
+    --pretty` (falling back to the hostname, then "HiFiBerry") and announce
+    that, but MPD kept the static zeroconf_name "HiFiBerry MPD" from the
+    shipped config -- so on one device the same speaker showed up under two
+    different names, and on a multi-device setup every MPD looked identical.
+    configure-mpd now writes zeroconf_name on each start, using the same
+    fallback order. Names containing " or \ are escaped for MPD's config
+    tokenizer.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 10:00:00 +0200
+
 hifiberry-mpd (0.24.13.4) stable; urgency=medium
 
   * Stop shipping the upstream user mpd.socket. Its postinst enabled it, so


### PR DESCRIPTION
`start-shairport.sh` and `start-librespot.sh` both resolve the device name the same way:

```sh
# Get the pretty hostname first, then try normal hostname, and finally use HiFiBerry as fallback
PRETTY_HOSTNAME=$(hostnamectl hostname --pretty 2>/dev/null)
...
```

and announce that (`--name=${PRETTY_HOSTNAME}`). MPD doesn't: it keeps the static `zeroconf_name "HiFiBerry MPD"` from the shipped `mpd.conf`, so setting a pretty hostname renames AirPlay and Spotify Connect but not MPD.

On a single device that means the same speaker shows up under two different names. On a multi-device setup it's worse — every device advertises `_mpd._tcp` as "HiFiBerry MPD", and mDNS disambiguates them as "HiFiBerry MPD #2", "#3", … in whatever order they happened to boot, so there's no way to tell which is which.

MPD has no command-line option for the service name (`mpd(1)` has only `--help/--kill/--no-config/--no-daemon/--stderr/--systemd/--verbose/--version`); `zeroconf_name` is read from the config file only. So this writes it from `configure-mpd`, which already rewrites the user config on every start for the mixer settings — the name is set right alongside, using the same fallback order as the other two wrappers.

Notes:

- Only the `zeroconf_name` line is touched; every other line is passed through unchanged, so a hand-edited `~/etc/mpd.conf` keeps its settings. If the key is absent it's appended.
- Names containing `"` or `\` are escaped — MPD's config tokenizer (`Tokenizer::NextString`) treats `\` as an escape inside quoted strings, so an unescaped quote would truncate the value.
- Verified round-trip against MPD's tokenizer semantics for `Marcel's Room`, `A & B / C \ D`, `He said "hi"`, `Küche` and similar; repeated runs are idempotent.
- Zeroconf has to actually be reachable for this to be visible — worth noting it only started working at all with the `mpd.socket` removal in #619.
