### PR TITLE
Add issue forms and support policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,150 @@
+name: Bug report
+description: Report a reproducible problem in HiFiBerryOS
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This tracker covers the current, Debian-based HiFiBerryOS only.
+        Problems with the older Buildroot-based images cannot be fixed here —
+        please contact [support](https://support.hifiberry.com) instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you start
+      options:
+        - label: I am running the current version of HiFiBerryOS
+          required: true
+        - label: I searched the existing issues and this is not a duplicate
+          required: true
+        - label: This is a defect, not a support or setup question
+          required: true
+
+  - type: dropdown
+    id: pi-model
+    attributes:
+      label: Raspberry Pi model
+      options:
+        - Raspberry Pi 3 Model A+
+        - Raspberry Pi 3 Model B
+        - Raspberry Pi 3 Model B+
+        - Raspberry Pi 4 Model B
+        - Raspberry Pi 5
+        - Compute Module 4
+        - Compute Module 5
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hat
+    attributes:
+      label: HiFiBerry board
+      options:
+        - DAC8x/ADC8x
+        - DAC8x
+        - Digi2 Pro
+        - Amp100
+        - Amp3
+        - Amp4
+        - Amp4 Pro
+        - DAC+ ADC Pro
+        - DAC+ ADC
+        - DAC2 ADC Pro
+        - DAC2 HD
+        - DAC+ DSP
+        - DAC+/Amp2
+        - DAC+ Pro
+        - DAC2 Pro
+        - Amp+
+        - Digi+ Pro
+        - Digi+
+        - Beocreate 4-Channel Amplifier
+        - DAC+ Light
+        - DAC+ Zero
+        - MiniAmp
+        - ADC
+        - HDMI Audio
+        - None / other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - MPD (local music)
+        - Librespot (Spotify Connect)
+        - Raat (Roon)
+        - Shairport (AirPlay)
+        - Squeezelite
+        - Bluetooth
+        - WebUI
+        - AudioControl (ACR)
+        - Network / Wi-Fi
+        - DSP
+        - Installation / upgrade
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: supportinfo
+    attributes:
+      label: Output of config-supportinfo
+      description: |
+        Run `config-supportinfo` on the affected device and paste the complete
+        output. It removes passwords and keys before printing. If the device
+        does not boot far enough to run it, write "device does not boot" and
+        describe the hardware instead.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What is wrong?
+      description: Describe the problem in a few sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected and actual behaviour
+      description: What did you expect to happen, and what happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Additional logs
+      description: |
+        Anything else that helps, for example `journalctl -b -u mpd` for a
+        player problem. Remove passwords and keys before pasting.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: testing
+    attributes:
+      label: Testing
+      options:
+        - label: I can test a fix on my device
+          required: false

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -80,6 +80,7 @@ body:
         - Raat (Roon)
         - Shairport (AirPlay)
         - Squeezelite
+        - Sendspin (Music Assistant)
         - Bluetooth
         - WebUI
         - AudioControl (ACR)

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Suggest a new capability for HiFiBerryOS
+labels: ["feature request"]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the existing issues and this is not a duplicate
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - WebUI
+        - Players / streaming services
+        - Audio routing
+        - Network
+        - DSP
+        - Installation / upgrade
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the situation you are in, not the solution you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support and user questions
+    url: https://support.hifiberry.com
+    about: Setup help, hardware questions and purchase advice belong in support, not in the issue tracker.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,28 @@
+# Getting help
+
+## Questions, setup problems, hardware advice
+
+Please use [HiFiBerry support](https://support.hifiberry.com). The issue
+tracker is for reproducible defects and feature requests in HiFiBerryOS, not
+for individual support cases.
+
+## Reporting a bug
+
+Open a [bug report](https://github.com/hifiberry/hifiberry-os/issues/new?template=01-bug-report.yml).
+The form asks for the output of:
+
+```
+config-supportinfo
+```
+
+That command ships with `hifiberry-configurator` and collects the hardware,
+package versions, service state and recent errors we need. It removes
+passwords, keys and tokens before printing, and it does not include your
+device UUID or hostname.
+
+## A note on older HiFiBerryOS versions
+
+HiFiBerryOS has been rewritten and is now based on Debian. Issues about the
+older, Buildroot-based images cannot be carried over and are closed as
+outdated. If you still see a problem on the current version, please open a new
+bug report.


### PR DESCRIPTION
Adds bug report and feature request forms, disables blank issues and points user questions at support.hifiberry.com.

The bug form requires the output of `config-supportinfo`, which shipped in hifiberry-configurator 2.15.1 and is available from debianrepo.hifiberry.com.

Prepares reopening the issue tracker.