### PR TITLE
issues: update support link, soften redaction claim, cover missing config-supportinfo

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         This tracker covers the current, Debian-based HiFiBerryOS only.
         Problems with the older Buildroot-based images cannot be fixed here —
-        please contact [support](https://support.hifiberry.com) instead.
+        please contact [support](https://support.hifiberry.com/forum/c/software) instead.
 
   - type: checkboxes
     id: preflight
@@ -97,9 +97,11 @@ body:
       label: Output of config-supportinfo
       description: |
         Run `config-supportinfo` on the affected device and paste the complete
-        output. It removes passwords and keys before printing. If the device
-        does not boot far enough to run it, write "device does not boot" and
-        describe the hardware instead.
+        output. It removes passwords and keys before printing; review the
+        output before posting it anyway. If the command is not found, update
+        first with `sudo apt update && sudo apt install --only-upgrade hifiberry-configurator`.
+        If the device does not boot far enough to run it, write "device does
+        not boot" and describe the hardware instead.
       render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Support and user questions
-    url: https://support.hifiberry.com
+    url: https://support.hifiberry.com/forum/c/software
     about: Setup help, hardware questions and purchase advice belong in support, not in the issue tracker.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -2,9 +2,9 @@
 
 ## Questions, setup problems, hardware advice
 
-Please use [HiFiBerry support](https://support.hifiberry.com). The issue
-tracker is for reproducible defects and feature requests in HiFiBerryOS, not
-for individual support cases.
+Please use [HiFiBerry support](https://support.hifiberry.com/forum/c/software).
+The issue tracker is for reproducible defects and feature requests in
+HiFiBerryOS, not for individual support cases.
 
 ## Reporting a bug
 
@@ -15,10 +15,16 @@ The form asks for the output of:
 config-supportinfo
 ```
 
+If the command is not found, update the package first:
+
+```
+sudo apt update && sudo apt install --only-upgrade hifiberry-configurator
+```
+
 That command ships with `hifiberry-configurator` and collects the hardware,
 package versions, service state and recent errors we need. It removes
 passwords, keys and tokens before printing, and it does not include your
-device UUID or hostname.
+device UUID or hostname — review the output before posting it anyway.
 
 ## A note on older HiFiBerryOS versions
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Bug reports ask for the output of `config-supportinfo`, which collects the
 hardware, package versions and recent errors we need.
 
 Questions about setup, hardware or purchases are better placed with
-[HiFiBerry support](https://support.hifiberry.com).
+[HiFiBerry support](https://support.hifiberry.com/forum/c/software).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Update every link to `https://support.hifiberry.com` to point at `https://support.hifiberry.com/forum/c/software` (`.github/ISSUE_TEMPLATE/config.yml`, `.github/ISSUE_TEMPLATE/01-bug-report.yml`, `.github/SUPPORT.md`, `README.md`). Anchor text left unchanged.
- Soften the redaction claim in the bug form and SUPPORT.md: both stated as absolutes that `config-supportinfo` "removes passwords and keys/tokens"; add the same caveat the command's man page already has ("review the output before posting it anyway").
- Add guidance for the far more common case of `config-supportinfo` not existing yet on an older `hifiberry-configurator`: `sudo apt update && sudo apt install --only-upgrade hifiberry-configurator`, in the form field description and in SUPPORT.md next to the command.

## Test plan
- [x] Both issue-template YAML files parse with `yaml.safe_load`
- [x] Every body element has a supported type; non-markdown elements have unique ids; `validations.required` only appears on types that support it
- [x] `grep -r https://support.hifiberry.com` repo-wide shows no remaining bare link (only the new `/forum/c/software` target and unrelated `support@hifiberry.com` email addresses)