### PR TITLE
issues: make the preflight checkbox verifiable

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Before you start
       options:
-        - label: I am running the current version of HiFiBerryOS
+        - label: I updated all packages with `sudo apt update && sudo apt upgrade`
           required: true
         - label: I searched the existing issues and this is not a duplicate
           required: true


### PR DESCRIPTION
## Summary
- Reword the first preflight checkbox in `.github/ISSUE_TEMPLATE/01-bug-report.yml` from "I am running the current version of HiFiBerryOS" (unverifiable — nothing told users how to check) to "I updated all packages with `sudo apt update && sudo apt upgrade`" — a concrete action the user can just perform.
- Other two preflight checkboxes, all field ids, and all required flags are untouched.

## Test plan
- [x] YAML parses with `yaml.safe_load`
- [x] Every body element has a supported type; non-markdown elements have unique ids; `validations.required` only on types that support it