### PR TITLE
Mention the WebUI path to the support report

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -97,11 +97,13 @@ body:
       label: Output of config-supportinfo
       description: |
         Run `config-supportinfo` on the affected device and paste the complete
-        output. It removes passwords and keys before printing; review the
-        output before posting it anyway. If the command is not found, update
-        first with `sudo apt update && sudo apt install --only-upgrade hifiberry-configurator`.
-        If the device does not boot far enough to run it, write "device does
-        not boot" and describe the hardware instead.
+        output, or get the same report from the web interface under
+        Settings → System Tools → Support Report, which also offers it as a
+        file. It removes passwords and keys before printing, but please read it
+        before posting. If the command is missing, update first with
+        `sudo apt update && sudo apt install --only-upgrade hifiberry-configurator`.
+        If the device does not boot far enough to run it, write "device does not
+        boot" and describe the hardware instead.
       render: shell
     validations:
       required: true

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -26,6 +26,12 @@ package versions, service state and recent errors we need. It removes
 passwords, keys and tokens before printing, and it does not include your
 device UUID or hostname — review the output before posting it anyway.
 
+No terminal access? The same report is available from the web interface,
+under Settings → System Tools → Support Report. It shows the report on the
+page for copying, and a "Download as file" button saves it so you can attach
+it to the issue directly. Since the endpoint is authenticated, you will be
+asked for the device password.
+
 ## A note on older HiFiBerryOS versions
 
 HiFiBerryOS has been rewritten and is now based on Debian. Issues about the


### PR DESCRIPTION
The bug form requires the config-supportinfo output; users without terminal access can now get the same report from Settings → System Tools.