### PR TITLE
Adjust control dependencies to work correctly with Trixie

### DIFF
--- a/packages/librespot/src/debian/control
+++ b/packages/librespot/src/debian/control
@@ -20,8 +20,8 @@ Vcs-Browser: https://github.com/hifiberry/hifiberry-os
 Package: hifiberry-librespot
 Architecture: arm64
 Depends: ${shlibs:Depends}, ${misc:Depends},
-         libasound2,
-         libssl3 | libssl1.1,
+         libasound2 | libasound2t64,
+         libssl3 | libssl3t64 | libssl1.1,
          libdbus-1-3,
          libglib2.0-0,
          hifiberry-configurator

--- a/packages/shairport-sync/src/debian/control
+++ b/packages/shairport-sync/src/debian/control
@@ -38,7 +38,7 @@ Vcs-Browser: https://github.com/mikebrady/shairport-sync
 Package: hifiberry-shairport
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
-         libssl3,
+         libssl3 | libssl3t64,
          libavahi-client3,
          libpopt0,
          libconfig11 | libconfig9,
@@ -51,7 +51,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          uuid-dev,
          libsystemd0,
          libcap2-bin,
-         libglib2.0-0,
+         libglib2.0-0 | libglib2.0-0t64,
          adduser,
          hifiberry-configurator
 Provides: shairport-sync, nqptp

--- a/packages/songrec/debian/control
+++ b/packages/songrec/debian/control
@@ -24,9 +24,9 @@ Package: songrec
 Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         libasound2,
+         libasound2 | libasound2t64,
          libpulse0,
-         libssl3,
+         libssl3 | libssl3t64,
          ffmpeg,
          libgtk-4-1 (>= 4.14),
          libadwaita-1-0 (>= 1.5),

--- a/packages/squeezelite/src/debian/control
+++ b/packages/squeezelite/src/debian/control
@@ -21,7 +21,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          libflac14 | libflac12,
          libmad0,
          libvorbis0a,
-         libmpg123-0,
+         libmpg123-0 | libmpg123-0t64,
          libfaad2,
          hifiberry-configurator,
          adduser


### PR DESCRIPTION
This PR changes dependencies for Trixie. Due to the t64 switch in Trixie I had dependency resolving issues.

I am aware that there are other packages such as ACR, suffering the same problem. Since that is a separate git repository, those changes are not in this PR.

Example change:

`libasound2` to ` libasound2 | libasound2t64`