### PR TITLE
Refine cross-compile: Improve consistency, add autorec for cross-compile

### DIFF
--- a/packages/acr/build.sh
+++ b/packages/acr/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 # Define variables
 SOURCE_PACKAGE="acr"
 REPO_URL="https://github.com/hifiberry/acr"

--- a/packages/autorec/build.sh
+++ b/packages/autorec/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 # Define variables
 PACKAGE="autorec"
 DEB_PACKAGE="hifiberry-autorec"
@@ -33,9 +37,27 @@ else
     cd "$PACKAGE"
 fi
 
+# Check for DIST environment variable
+if [ -n "$DIST" ]; then
+    echo "Using distribution from DIST environment variable: $DIST"
+    CHROOT="${DIST}-amd64-sbuild"
+    DIST_ARG="--dist=$DIST"
+    CHROOT_ARG="--chroot=$CHROOT"
+else
+    echo "No DIST environment variable set, using sbuild default"
+    DIST_ARG=""
+    CHROOT_ARG=""
+fi
+
 # Step 2: Build Debian package using dpkg-buildpackage
-echo "Building $DEB_PACKAGE Debian package..."
-dpkg-buildpackage -us -uc -b
+echo "Building $DEB_PACKAGE Debian package with sbuild..."
+sbuild \
+    --chroot-mode=unshare \
+    --no-clean-source \
+    --enable-network \
+    $DIST_ARG \
+    $CHROOT_ARG \
+    --verbose
 
 # Step 3: Move built packages back to package directory
 cd ..

--- a/packages/bluetooth-service/build.sh
+++ b/packages/bluetooth-service/build.sh
@@ -5,11 +5,7 @@ set -e
 
 # Enable cross-compile support if configured
 _CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
-if [ -f "$_CC_ENV" ]; then 
-    source "$_CC_ENV"
-else 
-    echo "Not using cross-compilation (${_CC_ENV} does not exist)"
-fi
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
 
 # Define variables
 PACKAGE="hbos-bluetooth"

--- a/packages/configurator/build.sh
+++ b/packages/configurator/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 # Define variables
 PACKAGE="configurator"
 REPO_URL="https://github.com/hifiberry/configurator"

--- a/packages/dspprofiles/build.sh
+++ b/packages/dspprofiles/build.sh
@@ -5,11 +5,7 @@ set -e
 
 # Enable cross-compile support if configured
 _CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
-if [ -f "$_CC_ENV" ]; then 
-    source "$_CC_ENV"
-else 
-    echo "Not using cross-compilation (${_CC_ENV} does not exist)"
-fi
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
 
 SCRIPT_DIR="$(dirname $(realpath $0))"
 DSP_PROFILES_URL="https://github.com/hifiberry/dspprofiles"

--- a/packages/freqresp/build.sh
+++ b/packages/freqresp/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 PACKAGE="freqresp"
 SRC_DIR="$(dirname $(realpath $0))/src"
 SCRIPT_DIR="$(dirname $(realpath $0))"

--- a/packages/hifiberry-auth/build.sh
+++ b/packages/hifiberry-auth/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 # Define variables
 PACKAGE="hifiberry-auth"
 REPO_URL="https://github.com/hifiberry/hifiberry-auth"

--- a/packages/pw-api/build.sh
+++ b/packages/pw-api/build.sh
@@ -4,11 +4,7 @@ set -e
 
 # Enable cross-compile support if configured
 _CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
-if [ -f "$_CC_ENV" ]; then 
-    source "$_CC_ENV"
-else 
-    echo "Not using cross-compilation (${_CC_ENV} does not exist)"
-fi
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
 
 # Define variables
 PACKAGE="pipewire-api"

--- a/packages/roomeq/build.sh
+++ b/packages/roomeq/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 # Define variables
 SOURCE_PACKAGE="roomeq"
 REPO_URL="https://github.com/hifiberry/roomeq"

--- a/packages/sendspin/build.sh
+++ b/packages/sendspin/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -e
+
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 PACKAGE="sendspin"
 REPO_URL="https://github.com/hifiberry/sendspin"
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"

--- a/packages/speakereq/build.sh
+++ b/packages/speakereq/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 # Define variables
 PACKAGE="speakereq"
 REPO_URL="https://github.com/hifiberry/speakereq"

--- a/packages/webui/build.sh
+++ b/packages/webui/build.sh
@@ -3,6 +3,10 @@
 # Exit on error
 set -e
 
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
 # Define variables
 PACKAGE="hifiberry-webui"
 REPO_URL="https://github.com/hifiberry/hbos-ui"


### PR DESCRIPTION
1. This PR makes cross-compile more consistent across all scripts, the calls are now identical everywhere.

2. This PR adds cross-compilation for package `autorec`  using sbuild, removing `dpkg-buildpackage`. 

3. Lastly, the cross-compilation check for ACR package is currently in ACR repository `build.sh` script, this PR moves it into the build.sh script of this repository where is should actually exist. 

The ACR PR is also up: https://github.com/hifiberry/acr/pull/15