### PR TITLE
Document the power key and the Pi 5 caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The next-generation HiFiBerryOS is a complete rewrite, now based on a standard D
 ## Documentation
 
 - [Add your own player](docs/add-your-own-player.md)
+- [Power key](docs/power-key.md) — stop the power button on a remote from shutting the system down
 
 ## Reporting bugs
 

--- a/docs/power-key.md
+++ b/docs/power-key.md
@@ -1,0 +1,83 @@
+# Power Key
+
+Pressing the power button on a remote control shuts the whole system down. On a
+device used only as a music player that is usually what you want, but on a Pi
+that also runs other services it means an accidental press takes everything
+down.
+
+This page explains where that behaviour comes from and how to change it.
+
+## Where it comes from
+
+No HiFiBerry component handles the power key. AudioControl reads remote
+controls and binds volume, mute, play/pause, stop and next/previous — but never
+`KEY_POWER`.
+
+The key is claimed by `systemd-logind`, which acts on `KEY_POWER` from every
+input device that udev tags as `power-switch`. Its default is
+`HandlePowerKey=poweroff`. We ship no configuration for this, so the stock
+systemd default applies on every installation.
+
+## Changing it
+
+Create a drop-in and reload logind:
+
+```bash
+sudo mkdir -p /etc/systemd/logind.conf.d
+sudo tee /etc/systemd/logind.conf.d/10-powerkey.conf >/dev/null <<'EOF'
+[Login]
+HandlePowerKey=ignore
+EOF
+sudo systemctl restart systemd-logind
+```
+
+The three settings that make sense:
+
+| Behaviour wanted | Configuration |
+| --- | --- |
+| Any press shuts down (default) | no file, or `HandlePowerKey=poweroff` |
+| Power key does nothing | `HandlePowerKey=ignore` |
+| Only a long press shuts down | `HandlePowerKey=ignore` and `HandlePowerKeyLongPress=poweroff` |
+
+For the third one:
+
+```bash
+sudo tee /etc/systemd/logind.conf.d/10-powerkey.conf >/dev/null <<'EOF'
+[Login]
+HandlePowerKey=ignore
+HandlePowerKeyLongPress=poweroff
+EOF
+sudo systemctl restart systemd-logind
+```
+
+To go back to the default, delete the file and restart `systemd-logind` again.
+
+Check what is actually in effect — this also shows any other drop-in that might
+override yours:
+
+```bash
+systemd-analyze cat-config systemd/logind.conf | grep -i handlepowerkey
+```
+
+## The Pi 5 caveat
+
+**On a Pi 5, `HandlePowerKey=ignore` also disables the onboard power button.**
+
+logind cannot tell the two apart. The Pi 5's button is a `gpio-keys` device
+that emits exactly the same `KEY_POWER` as a remote control, so one setting
+covers both. Disabling the key removes the only way to shut a headless Pi 5
+down cleanly without a network connection.
+
+On a Pi 5, prefer `longpress`: accidental presses on the remote do nothing,
+while holding the onboard button still shuts the system down.
+
+Powering the board back on with the button is handled by the firmware, not by
+logind, and is not affected by any of this.
+
+Pi 4 and earlier have no onboard power button, so there the setting only ever
+affects remote controls.
+
+## Related
+
+- `logind.conf(5)`, `systemd-logind(8)`
+- [hifiberry-os#635](https://github.com/hifiberry/hifiberry-os/issues/635)


### PR DESCRIPTION
The power button on a remote control shuts the whole system down, which is unwelcome on a Pi that also runs other services ([forum report](https://support.hifiberry.com/forum/c/software/10866)).

Nothing in HiFiBerry handles the key — AudioControl never binds `KEY_POWER` — so there was nothing to point users at. It is `systemd-logind`, which acts on `KEY_POWER` from every input device udev tags as `power-switch`, with an upstream default of `HandlePowerKey=poweroff`.

Adds `docs/power-key.md` covering:

- where the behaviour comes from
- the three sensible configurations: default, `ignore`, and `ignore` + `HandlePowerKeyLongPress=poweroff`
- how to check what is actually in effect, including foreign drop-ins
- why the default stays as it is: logind cannot tell a remote apart from a power button wired to the board, so ignoring the key also disables the onboard button of a Pi 5 — and with it the only way to shut such a system down without a network connection. `longpress` is the answer there.

Documentation only, no code changes. A `config-powerkey` tool was considered and dropped: with the default unchanged it would have wrapped a four-line file write in a few hundred lines of code, and it is pure systemd configuration with nothing HiFiBerry-specific about it.

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)