### PR TITLE
Correct build.sh scripts, for which cloned repo could not build standalone.

### DIFF
--- a/packages/dspprofiles/build.sh
+++ b/packages/dspprofiles/build.sh
@@ -16,7 +16,7 @@ DSP_PROFILES_URL="https://github.com/hifiberry/dspprofiles"
 DSP_PROFILES_CHECKOUT="$SCRIPT_DIR/dspprofiles"
 PACKAGE="dspprofiles"
 
-export BUILD_DIR="/tmp/${PACKAGE}-build"
+BUILD_DIR="/tmp/${PACKAGE}-build"
 
 # Prepare build directory
 echo "Preparing build directory..."
@@ -54,16 +54,6 @@ update_dspprofiles() {
     fi
     echo "DSP profiles updated successfully"
 }
-
-# Check for DIST environment variable
-if [ -n "$DIST" ]; then
-    echo "Using distribution from DIST environment variable: $DIST"
-    export DIST_ARG="--dist=$DIST"
-    export CHROOT_ARG="--chroot=$CHROOT"
-else
-    export DIST_ARG=""
-    export CHROOT_ARG=""
-fi
 
 # Update or clone the repository
 update_dspprofiles

--- a/packages/dspprofiles/build.sh
+++ b/packages/dspprofiles/build.sh
@@ -16,15 +16,6 @@ DSP_PROFILES_URL="https://github.com/hifiberry/dspprofiles"
 DSP_PROFILES_CHECKOUT="$SCRIPT_DIR/dspprofiles"
 PACKAGE="dspprofiles"
 
-BUILD_DIR="/tmp/${PACKAGE}-build"
-
-# Prepare build directory
-echo "Preparing build directory..."
-rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR"
-
-echo "DSP Profiles build script"
-
 # Function to update or clone dspprofiles
 update_dspprofiles() {
     echo "Updating DSP profiles..."

--- a/packages/input-processor/build.sh
+++ b/packages/input-processor/build.sh
@@ -12,17 +12,7 @@ PACKAGE="input-processor"
 DEB_PACKAGE="hifiberry-input-processor"
 REPO_URL="https://github.com/hifiberry/input-processor.git"
 
-export BUILD_DIR="/tmp/${PACKAGE}-build"
-
-if [ -n "$DIST" ]; then
-    echo "Using distribution from DIST environment variable: $DIST"
-    export DIST_ARG="--dist=$DIST"
-    export CHROOT_ARG="--chroot=$CHROOT"
-else
-    echo "No DIST environment variable set, using sbuild default"
-    export DIST_ARG=""
-    export CHROOT_ARG=""
-fi
+BUILD_DIR="/tmp/${PACKAGE}-build"
 
 # Function to clean up build and downloaded files
 clean() {

--- a/packages/input-processor/build.sh
+++ b/packages/input-processor/build.sh
@@ -12,12 +12,9 @@ PACKAGE="input-processor"
 DEB_PACKAGE="hifiberry-input-processor"
 REPO_URL="https://github.com/hifiberry/input-processor.git"
 
-BUILD_DIR="/tmp/${PACKAGE}-build"
-
 # Function to clean up build and downloaded files
 clean() {
     echo "Cleaning up build files..."
-    rm -rf "$BUILD_DIR"
     rm -f $PACKAGE*.build $PACKAGE*.changes $PACKAGE*.dsc $PACKAGE*.deb $PACKAGE*.buildinfo $PACKAGE*.tar.gz
     echo "Cleanup completed."
 }
@@ -27,10 +24,6 @@ if [[ "$1" == "--clean" ]]; then
     clean
     exit 0
 fi
-
-echo "Preparing build directory..."
-rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR"
 
 # Step 1: Clone or update the GitHub repository
 if [[ -d "$PACKAGE/.git" ]]; then
@@ -52,10 +45,6 @@ rm -f ../hifiberry-input-processor-dbgsym*.deb
 
 # Step 3: Move built packages back to package directory
 cd ..
-mv $BUILD_DIR/${DEB_PACKAGE}_*.deb . 2>/dev/null || true
-mv $BUILD_DIR/${DEB_PACKAGE}_*.build . 2>/dev/null || true
-mv $BUILD_DIR/${DEB_PACKAGE}_*.buildinfo . 2>/dev/null || true
-mv $BUILD_DIR/${DEB_PACKAGE}_*.changes . 2>/dev/null || true
 
 echo "Package build completed."
 echo "Built packages:"

--- a/packages/pw-api/build.sh
+++ b/packages/pw-api/build.sh
@@ -13,18 +13,8 @@ fi
 # Define variables
 PACKAGE="pipewire-api"
 DEB_PACKAGE="pipewire-api"
-REPO_URL="https://github.com/hifiberry/pipewire-api"
-export BUILD_DIR="/tmp/${PACKAGE}-build"
-
-# Check for DIST environment variable
-if [ -n "$DIST" ]; then
-    echo "Using distribution from DIST environment variable: $DIST"
-    export DIST_ARG="--dist=$DIST"
-    export CHROOT_ARG="--chroot=$CHROOT"
-else
-    export DIST_ARG=""
-    export CHROOT_ARG=""
-fi
+REPO_URL="https://github.com/LarsGrootkarzijn/pipewire-api.git"
+BUILD_DIR="/tmp/${PACKAGE}-build"
 
 # Function to clean up build and downloaded files
 clean() {

--- a/packages/pw-api/build.sh
+++ b/packages/pw-api/build.sh
@@ -14,12 +14,10 @@ fi
 PACKAGE="pipewire-api"
 DEB_PACKAGE="pipewire-api"
 REPO_URL="https://github.com/hifiberry/pipewire-api"
-BUILD_DIR="/tmp/${PACKAGE}-build"
 
 # Function to clean up build and downloaded files
 clean() {
     echo "Cleaning up build and downloaded files..."
-    rm -rf "$BUILD_DIR"
     rm -rf "$PACKAGE"
     rm -f $PACKAGE*.build $PACKAGE*.changes $PACKAGE*.dsc $PACKAGE*.deb $PACKAGE*.buildinfo $PACKAGE*.tar.gz
     echo "Cleanup completed."
@@ -60,11 +58,6 @@ check_version_consistency() {
     echo "✓ All versions consistent: $debian_version"
 }
 
-# Prepare build directory
-echo "Preparing build directory..."
-rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR"
-
 # Clone or update repository
 if [[ -d "$PACKAGE/.git" ]]; then
     echo "Updating $PACKAGE source from $REPO_URL..."
@@ -90,10 +83,6 @@ rm -f ../${DEB_PACKAGE}-dbgsym*.deb
 
 # Move built packages to package directory
 cd ..
-mv $BUILD_DIR/${DEB_PACKAGE}_*.deb . 2>/dev/null || true
-mv $BUILD_DIR/${DEB_PACKAGE}_*.build . 2>/dev/null || true
-mv $BUILD_DIR/${DEB_PACKAGE}_*.buildinfo . 2>/dev/null || true
-mv $BUILD_DIR/${DEB_PACKAGE}_*.changes . 2>/dev/null || true
 
 echo "Package build completed."
 echo "Built packages:"

--- a/packages/pw-api/build.sh
+++ b/packages/pw-api/build.sh
@@ -13,7 +13,7 @@ fi
 # Define variables
 PACKAGE="pipewire-api"
 DEB_PACKAGE="pipewire-api"
-REPO_URL="https://github.com/LarsGrootkarzijn/pipewire-api.git"
+REPO_URL="https://github.com/hifiberry/pipewire-api"
 BUILD_DIR="/tmp/${PACKAGE}-build"
 
 # Function to clean up build and downloaded files


### PR DESCRIPTION
Hello,

This is the last bunch of PR's that is needed for the full sbuild migration. Additionally, it fixes some packages which could not build standalone. This PR effects four packages: nowplaying-sdl, input-processor, pipewire-api, sendspin and dspprofiles. Autorec was migrated in https://github.com/hifiberry/hifiberry-os/pull/633.

Since the above mentioned packages are all their own repo, this means they need the changes downstream. I have done the work and opened PRs for all of them:

1. nowplaying-sdl: https://github.com/hifiberry/nowplaying-sdl/pull/2
2. input-processor: https://github.com/hifiberry/input-processor/pull/2
3. pipewire-api: https://github.com/hifiberry/pipewire-api/pull/1
4. sendspin: https://github.com/hifiberry/sendspin/pull/1
5. dspprofiles: https://github.com/hifiberry/dspprofiles/pull/2

Please let me know what you think, with these changes the **full project** is migrated to sbuild AND the full project can be cross-compiled.