### PR TITLE
fix(packaging): give hbos-minimal a Bluetooth audio backend

### DIFF
--- a/packages/hifiberryos/src/debian/changelog
+++ b/packages/hifiberryos/src/debian/changelog
@@ -1,3 +1,18 @@
+hifiberryos-meta (0.14) unstable; urgency=medium
+
+  * hbos-minimal: add bluez and libspa-0.2-bluetooth. Until now
+    libspa-0.2-bluetooth -- the SPA plugin PipeWire needs to register A2DP
+    endpoints with BlueZ -- was pulled in only as a dependency of
+    hifiberry-bluetooth, which is part of hbos-full alone. A minimal
+    install therefore had no Bluetooth audio backend at all, while still
+    receiving 99-hifiberry-bluetooth.conf from hifiberry-pipewire-configs
+    and still offering the pairing toggle in the web interface. Phones
+    could pair but saw a generic device rather than a speaker, because no
+    A2DP service was ever published in the SDP record.
+    See hifiberry/hifiberry-os#641.
+
+ -- HiFiBerry <support@hifiberry.com>  Wed, 26 Aug 2026 19:00:00 +0000
+
 hifiberryos-meta (0.13) unstable; urgency=medium
 
   * hbos-full: drop hifiberry-librespot and hifiberry-shairport. Both are

--- a/packages/hifiberryos/src/debian/control
+++ b/packages/hifiberryos/src/debian/control
@@ -39,6 +39,8 @@ Depends: hifiberry-configurator,
          pipewire-bin,
          pipewire-pulse,
          wireplumber,
+         bluez,
+         libspa-0.2-bluetooth,
          i2c-tools,
          sox
 Description: HiFiBerry OS minimal meta-package
@@ -52,6 +54,7 @@ Description: HiFiBerry OS minimal meta-package
   - Audio control utilities (hifiberry-audiocontrol)
   - PipeWire audio server with optimized configurations (hifiberry-pipewire-configs)
   - Modern web interface (hifiberry-webui)
+  - Bluetooth audio backend for PipeWire (bluez, libspa-0.2-bluetooth)
  .
  This package is ideal for users who want a lightweight installation with
  essential audio functionality and web-based management.


### PR DESCRIPTION
## What

Adds `bluez` and `libspa-0.2-bluetooth` to the `hbos-minimal` dependency list.

## Why

`libspa-0.2-bluetooth` is the SPA plugin PipeWire needs in order to register A2DP endpoints with BlueZ. In our packaging it is declared in exactly one place — as a dependency of `hifiberry-bluetooth`, which is only part of `hbos-full`. `grep -rn libspa` across this repo returns nothing.

So an `hbos-minimal` install pulls in `pipewire`, `pipewire-pulse` and `wireplumber`, but nothing that depends on that plugin, and ends up with no Bluetooth audio backend at all. At the same time `hifiberry-pipewire-configs` installs `99-hifiberry-bluetooth.conf` (the `bluez5.auto-connect` rules) on every minimal install, where it is inert, and the web interface still shows the pairing toggle.

The user-visible result is #641: pairing succeeds, but Android shows the Pi with a phone icon rather than a loudspeaker, because no A2DP service is ever published in the SDP record. That issue was initially triaged as a possible hardware fault; it is a packaging gap.

## Notes for the reviewer

- `bluez` was previously only a `Recommends` of `hifiberry-pipewire-configs`. `bluetooth.service` is required for any of this to work, so it is a hard dependency here.
- **Alternative placement worth considering:** these could instead go on `hifiberry-pipewire-configs`, which is the package that actually ships the WirePlumber Bluetooth config and is present in both meta-packages. That is arguably the more coherent layer. It was put on `hbos-minimal` here to keep the change to the meta-package that defines the install profile, and because `hifiberry-pipewire-configs` is also installed standalone by people who may not want Bluetooth pulled in. Happy to move it if you prefer.
- **Related gap, not fixed here** (different repo): `hbos-bluetooth`'s `debian/control` depends on `libspa-0.2-bluetooth` and `systemd` but not on `bluez`, even though `hifiberry-bluetooth.service` declares `Requires=bluetooth.service`. Worth a follow-up in https://github.com/hifiberry/hbos-bluetooth.
- Not build-tested against a real minimal install — the dependency names are taken from Debian trixie. Worth a smoke test on a fresh `hbos-minimal` before release.

Refs #641, #642
