### PR TITLE
fix(bluetooth): start the bluez monitor on headless systems (root cause of #641/#642)

### DIFF
--- a/packages/pipewire-configs/src/debian/changelog
+++ b/packages/pipewire-configs/src/debian/changelog
@@ -1,3 +1,23 @@
+hifiberry-pipewire-configs (1.0.11) stable; urgency=medium
+
+  * 99-hifiberry-bluetooth.conf: disable WirePlumber's logind seat monitoring
+    for the bluez monitor. WirePlumber's monitors/bluez.lua only calls
+    createMonitor() when the logind seat state is "active". A HiFiBerryOS box
+    has no seat -- the player runs in a systemd user session with no console
+    or graphical login -- so the plugin reports "online", the monitor is never
+    created, and libspa-bluez5 is never loaded into the process at all.
+    BlueZ is then left with no A2DP media endpoint: the adapter advertises no
+    Audio Sink UUID (0000110b) and keeps a generic class of device, so phones
+    list it as a nondescript device rather than a speaker, and a phone that
+    does connect finds nothing to stream to and drops the link after a few
+    seconds.
+    Verified on a Pi 4: before, class 0x00400000 with no Audio Sink UUID and
+    libspa-bluez5 absent from the process; after, class 0x006c0000 with
+    Audio Sink and Audio Source advertised and the plugin loaded.
+    Closes hifiberry/hifiberry-os#641, hifiberry/hifiberry-os#642.
+
+ -- HiFiBerry <support@hifiberry.com>  Wed, 26 Aug 2026 20:30:00 +0000
+
 hifiberry-pipewire-configs (1.0.10) stable; urgency=medium
 
   * Add 98-hifiberry-digi-no-capture.conf: disable the S/PDIF capture node on

--- a/packages/pipewire-configs/src/etc/xdg/wireplumber/wireplumber.conf.d/99-hifiberry-bluetooth.conf
+++ b/packages/pipewire-configs/src/etc/xdg/wireplumber/wireplumber.conf.d/99-hifiberry-bluetooth.conf
@@ -1,3 +1,31 @@
+## Start the Bluetooth monitor on a headless system.
+##
+## WirePlumber's monitors/bluez.lua gates the monitor on logind:
+##
+##     if seat_state == "active" then
+##       monitor = createMonitor()
+##
+## On a HiFiBerryOS box there is no seat -- the player runs in a systemd
+## user session with no console or graphical login -- so the logind plugin
+## reports "online" and never "active", createMonitor() is never called, and
+## the bluez5 SPA plugin is never even loaded into the process. BlueZ then
+## has no A2DP media endpoint: the adapter advertises no Audio Sink UUID and
+## keeps a generic class of device, so phones show it as a nondescript device
+## rather than a speaker, and a phone that does connect finds nothing to
+## stream to and drops the link after a few seconds.
+##
+## Disabling seat monitoring makes bluez.lua take its other branch and create
+## the monitor unconditionally, which is what a headless appliance wants.
+## This is the same thing WirePlumber's own mixin.systemwide-session sets;
+## we apply just this one key rather than switching profiles wholesale.
+##
+## Fixes hifiberry/hifiberry-os#641 and #642.
+wireplumber.profiles = {
+  main = {
+    monitor.bluez.seat-monitoring = disabled
+  }
+}
+
 monitor.bluez.rules = [
   ## The list of monitor rules
 


### PR DESCRIPTION
## Root cause of #641 and #642

Both Bluetooth issues have one cause, and it is ours, not the users' hardware.

WirePlumber's `monitors/bluez.lua` gates the Bluetooth monitor on logind:

```lua
if config.seat_monitoring then
  logind_plugin = Plugin.find("logind")
end
if logind_plugin then
  -- if logind support is enabled, activate
  -- the monitor only when the seat is active
  function startStopMonitor(seat_state)
    log:info(logind_plugin, "Seat state changed: " .. seat_state)
    if seat_state == "active" then
      monitor = createMonitor()
    ...
else
  monitor = createMonitor()
end
```

A HiFiBerryOS box has no seat — the player runs in a systemd user session with no console or graphical login — so the logind plugin reports `"online"`, never `"active"`. `createMonitor()` is never called and `libspa-bluez5.so` is never even loaded into the process.

BlueZ is then left with no A2DP media endpoint. The adapter advertises no `Audio Sink (0000110b)` UUID and keeps a generic class of device, which produces both reported symptoms:

- **#641** — the Pi appears on Android as a nondescript device with a phone icon rather than a loudspeaker, because there is no A2DP service in its SDP record.
- **#642** — a phone pairs and connects, finds nothing to stream to, and drops the link after a few seconds.

We run the stock `main` profile, which leaves seat monitoring on. WirePlumber's own `mixin.systemwide-session` disables this exact key for precisely this situation; this change applies just that one key rather than switching profiles wholesale.

## Verified on hardware

Reproduced and fixed on a Pi 4 running hbos-full, with bluez 5.82, libspa-0.2-bluetooth 1.4.2 and wireplumber 0.5.8 all installed and running.

Before — a phone paired, connected, and dropped ~40s later, with the A2DP UUID never appearing:

```
[STATE 18:07:40] audiosink_uuid=0 bluez5_loaded=no connected=Device 80:B9:...;
[STATE 18:08:11] audiosink_uuid=0 bluez5_loaded=no connected=Device 80:B9:...;
[STATE 18:08:22] audiosink_uuid=0 bluez5_loaded=no connected=
```

```
Class: 0x00400000
UUID: A/V Remote Control Target (0000110c-...)
UUID: A/V Remote Control        (0000110e-...)
   (no Audio Sink)
```

After installing this exact file and restarting wireplumber:

```
bluez5 LOADED
Class: 0x006c0000
UUID: Audio Source              (0000110a-...)
UUID: Audio Sink                (0000110b-...)
```

Normal ALSA playback is unaffected — the `speakereq2x2` filter chain and `Built-in Audio Stereo` sink come up as before.

## Notes for the reviewer

- This is the real fix for #641, which was previously triaged as possible user hardware failure. It reproduces on our own Pi.
- Two earlier theories were tested and **disproved**, worth recording so nobody re-treads them: the `bluetooth` group is irrelevant (bluez 5.82 ships no group policy, only `<policy context="default"><allow send_destination="org.bluez"/></policy>`, and our own working box has no such group), and `/etc/xdg/wireplumber/wireplumber.conf.d/` **is** read by WirePlumber 0.5 — the debug log shows it opening our fragment and applying `monitor.bluez.rules` from it.
- The same key covers `monitor.bluez-midi`, which is gated identically, since both components hang off the `monitor.bluez.seat-monitoring` virtual component.
- The dependency fixes in #643 and hifiberry/hbos-bluetooth#3 remain necessary but were not sufficient on their own — the reference box had every package installed and still failed.

Closes #641
Closes #642
