### PR TITLE
Tell the reviewer what this repository cares about

### DIFF
--- a/.codereview.toml
+++ b/.codereview.toml
@@ -1,0 +1,19 @@
+instructions = """
+This repository packages and ships the OS. Most changes are Debian packaging
+and shell, and the failure they cause shows up on a customer's device during
+an unattended upgrade. Alongside the usual defects, report these:
+
+- A maintainer script (postinst, prerm, postrm) that is not idempotent, that
+  assumes a fresh install and breaks on upgrade, or that restarts the service
+  currently installing it.
+- A package that calls a binary or imports a module it does not declare in
+  `debian/control`, and a new package missing from the metapackage that is
+  supposed to pull it in.
+- Shell without `set -e`, unquoted variables or paths, or `rm -rf` on a
+  constructed path.
+- A systemd unit whose ordering or conditions assume hardware that may be
+  absent — no display, no Bluetooth adapter, no sound card — and that fails
+  the boot or the install when it is.
+- A change to a build or cross-compile script that works from the maintainer
+  checkout but not from a clean clone.
+"""


### PR DESCRIPTION
Adds a `.codereview.toml` so the automated reviewer knows what this repository is for.

**No effort level, deliberately.** Changes here are mostly packaging and shell across a high PR cadence; the useful review is checklist-shaped rather than reasoning-shaped, and raising the effort would buy little for the wall-clock it costs. Easy to add `effort = \"high\"` later if it under-reports.

The checks are drawn from what has actually bitten this repo: maintainer scripts that are not idempotent or that restart the service currently installing them; undeclared `debian/control` dependencies and packages missing from a metapackage; unquoted shell and `rm -rf` on constructed paths; systemd units that assume hardware which may be absent (no display, no Bluetooth adapter, no sound card); build scripts that only work from a maintainer checkout rather than a clean clone.

The reviewer (`hifiberry-codereview[bot]`, `thufir`) reads this file from the **base branch**, never from the pull request head — on the head it would be written by whoever opened the PR, who could then tell the reviewer reviewing them to stay quiet. So this file does not affect the review of this PR; it applies to the next one.

Instructions widen what gets reported: something named here is in scope even where the reviewer's standard prompt excludes it (missing tests, for instance, are normally excluded). They do not lower its bar for evidence.

See https://github.com/hifiberry/codereview#per-repository-guidance.