### PR TITLE
Recognise a git worktree as a repository in check-packages.py

### DIFF
--- a/scripts/check-packages.py
+++ b/scripts/check-packages.py
@@ -274,8 +274,20 @@ def main() -> int:
     args = parser.parse_args()
 
     root = os.path.abspath(args.root)
-    if not os.path.isdir(os.path.join(root, ".git")):
+
+    # Ask git rather than looking for a .git directory: in a worktree - and in
+    # a submodule - .git is a *file* pointing at the real git dir, so the
+    # directory test rejected a perfectly good checkout. That made the
+    # pre-push hook abort every push from a worktree, leaving
+    # SKIP_PACKAGE_CHECK=1 as the only way through, which skips the check
+    # rather than running it.
+    toplevel = git(root, "rev-parse", "--show-toplevel")
+    if not toplevel:
         print(f"not a git repository: {root}", file=sys.stderr)
+        return 2
+    if os.path.realpath(toplevel) != os.path.realpath(root):
+        print(f"not the top level of a repository: {root}", file=sys.stderr)
+        print(f"  try: --root {toplevel}", file=sys.stderr)
         return 2
 
     check_structure(root, args.online)


### PR DESCRIPTION
`scripts/check-packages.py` tested for a `.git` **directory**. In a worktree — and in a submodule — `.git` is a *file* pointing at the real git dir, so a perfectly good checkout was reported as:

```
not a git repository: /path/to/worktree
```

The pre-push hook calls this script, so **every push from a worktree aborted**, and the only documented way through was `SKIP_PACKAGE_CHECK=1` — which skips the check rather than running it. Worktrees are the convention for feature work, so the guard was quietly training people to bypass itself. That is how it was found: pushing a documentation branch from a worktree.

## The change

Ask git for the top level instead of guessing from the filesystem. A subdirectory is still refused, as before — the package scan is relative to the root — but it now says so and names the root to pass:

```
not the top level of a repository: /path/to/repo/packages
  try: --root /path/to/repo
```

## Verified

By exit code, in all four cases:

| Invocation | Exit | Before |
|---|---|---|
| from a worktree | 0 | 2, "not a git repository" |
| from the main checkout | 0 | 0 |
| from a subdirectory | 2 | 2, without the hint |
| outside any repository | 2 | 2 |

The structural checks themselves are untouched; this only fixes which directories the script agrees to run in. This branch was pushed with the hook active and the check passed.