### PR TITLE
Document the CSRF requirement on the policy write

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -212,8 +212,9 @@ exists.
 ## Auth API reference (`/api/auth/`)
 
 These endpoints are always reachable (nginx sets `auth_request off` for them),
-so the writes among them check the CSRF token themselves rather than relying on
-the gateway:
+so the writes that need a CSRF token check it themselves rather than relying on
+the gateway. `login` cannot require one — it mints the session that would carry
+it — and `set-password` takes the current password instead:
 
 | Endpoint | Method | Purpose |
 |---|---|---|

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -211,15 +211,17 @@ exists.
 
 ## Auth API reference (`/api/auth/`)
 
-These endpoints are always reachable (nginx sets `auth_request off` for them):
+These endpoints are always reachable (nginx sets `auth_request off` for them),
+so the writes among them check the CSRF token themselves rather than relying on
+the gateway:
 
 | Endpoint | Method | Purpose |
 |---|---|---|
 | `/api/auth/status` | GET | Current `{protection, has_password, authenticated}` |
 | `/api/auth/set-password` | POST | Set/change the password (needs `current` when one exists); mints a session |
 | `/api/auth/login` | POST | Sign in with the password (rate-limited); mints a session |
-| `/api/auth/logout` | POST | End the session (requires a session + CSRF token) and clear the cookie |
-| `/api/auth/policy` | POST | Set the protection policy (`off`/`risky`/`all`); requires a session |
+| `/api/auth/logout` | POST | End the session (requires a session + CSRF token); clears the cookie only when it succeeds |
+| `/api/auth/policy` | POST | Set the protection policy (`off`/`risky`/`all`); requires a session + CSRF token |
 | `/api/auth/csrf` | GET | Return the current session's CSRF token (used to rehydrate after reload) |
 
 The internal `GET /_auth/verify` endpoint is the nginx subrequest target; it is


### PR DESCRIPTION
hifiberry-auth 0.2.1 (hifiberry/hifiberry-auth#3) closes two gaps on the `/api/auth` write surface, and the reference table described both as they were:

- setting the protection policy took a session and nothing else. `/api/auth/` is exempt from `auth_request`, so the gateway's "non-GET needs a CSRF token" rule never reached it either. It now requires one, like sign-out.
- a refused sign-out cleared the session cookie anyway. It is now cleared only when the sign-out actually succeeds — a refusal that deleted the cookie destroyed what the client needs to fetch a fresh token and retry.

Also says out loud that the endpoints under `/api/auth/` check the token themselves rather than relying on the gateway, since that is the reason the distinction exists at all.

Documentation only, and no ordering constraint against the code.