### PR TITLE
Build hifiberry-songcompare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ packages/input-processor/input-processor
 packages/nowplaying-sdl/nowplaying-sdl
 packages/pw-api/pipewire-api
 packages/songrec/songrec
+packages/songcompare/songcompare
 packages/speakereq/speakereq
 packages/vu-meter/src
 

--- a/.gitignore
+++ b/.gitignore
@@ -86,8 +86,8 @@ packages/bluetooth-service/hbos-bluetooth
 packages/input-processor/input-processor
 packages/nowplaying-sdl/nowplaying-sdl
 packages/pw-api/pipewire-api
-packages/songrec/songrec
 packages/songcompare/songcompare
+packages/songrec/songrec
 packages/speakereq/speakereq
 packages/vu-meter/src
 

--- a/packages/repos.md
+++ b/packages/repos.md
@@ -28,6 +28,7 @@ python3 scripts/git-repo-sync.py --root /home/matuschd/hifiberry-os --include-di
 | `packages/input-processor/input-processor` | https://github.com/hifiberry/input-processor | `main` | Analog input processor, optional RIAA phono EQ |
 | `packages/roomeq/roomeq` | https://github.com/hifiberry/roomeq | `main` | Room equalization |
 | `packages/sendspin/sendspin` | https://github.com/hifiberry/sendspin | `main` | Sendspin / Music Assistant player (`sendspind`, C++) |
+| `packages/songcompare/songcompare` | https://github.com/hifiberry/songcompare | `master` | A/B listening-comparison tool (`songcompare`, Rust) |
 | `packages/songrec/songrec` | https://github.com/marin-m/SongRec | — | Third-party: song recognition (pinned release, DETACHED HEAD) |
 | `packages/speakereq/speakereq` | https://github.com/hifiberry/speakereq | `main` | Speaker equalization |
 | `packages/tidal-connect` | https://github.com/pulpier/tidal-connect-hifiberry | `master` | Third-party: Tidal Connect |

--- a/packages/songcompare/README.md
+++ b/packages/songcompare/README.md
@@ -1,0 +1,18 @@
+# songcompare
+
+Builds `hifiberry-songcompare` from
+[github.com/hifiberry/songcompare](https://github.com/hifiberry/songcompare).
+
+Interactive A/B comparison of different renderings of the same recording:
+lossy against lossless, one master against another, a filter change against
+the unprocessed source. It level-matches the files, optionally aligns them by
+cross-correlation, and crossfades the switch so only the difference under test
+is audible. An anonymous mode hides the filenames until the comparison ends.
+
+The package installs a single binary, `/usr/bin/songcompare`. It is a
+listening-test tool run by hand, not a service, so it is in no `hbos-*`
+meta-package; install it on demand.
+
+`build.sh` clones the upstream repo (tracking `master`) and builds with sbuild;
+the upstream repo ships its own `debian/`, so there is no local overlay here.
+The build needs network access because cargo fetches the crate dependencies.

--- a/packages/songcompare/build.sh
+++ b/packages/songcompare/build.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+# Enable cross-compile support if configured
+_CC_ENV="$(dirname "$0")/../../scripts/cross-compile-env.sh"
+if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
+
+PACKAGE="songcompare"
+REPO_URL="https://github.com/hifiberry/songcompare"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR"
+
+if [[ "$1" == "--clean" ]]; then
+    rm -rf "$PACKAGE"
+    rm -f hifiberry-songcompare_* hifiberry-songcompare-*
+    echo "Cleanup completed."
+    exit 0
+fi
+
+# Clone or update upstream (tracks master HEAD)
+if [[ -d "$PACKAGE/.git" ]]; then
+    echo "Updating $PACKAGE from $REPO_URL..."
+    ( cd "$PACKAGE" && git pull )
+else
+    echo "Cloning $PACKAGE from $REPO_URL..."
+    git clone "$REPO_URL" "$PACKAGE"
+fi
+
+cd "$PACKAGE"
+
+if [ -n "$DIST" ]; then
+    DIST_ARG="--dist=$DIST"
+else
+    DIST_ARG=""
+fi
+
+# Network stays enabled: cargo fetches the crate dependencies during the build.
+echo "Building with sbuild..."
+sbuild --chroot-mode=unshare --enable-network --no-clean-source $DIST_ARG
+
+cd ..
+
+# Keep only the .deb; prune other build artifacts
+find . -maxdepth 1 \( -name "*.build" -o -name "*.buildinfo" -o -name "*.changes" \
+    -o -name "*.dsc" -o -name "*.tar.gz" -o -name "*.tar.xz" \) -delete
+
+LATEST_DEB=$(ls -t hifiberry-songcompare_*.deb 2>/dev/null | head -1)
+if [ -n "$LATEST_DEB" ]; then
+    ls -t hifiberry-songcompare_*.deb | tail -n +2 | xargs -r rm -f
+fi
+
+echo "Package created:"
+ls -lh hifiberry-songcompare_*.deb 2>/dev/null || ls -lh *.deb
+echo "Build completed successfully!"

--- a/packages/songcompare/clean.sh
+++ b/packages/songcompare/clean.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+echo "Cleaning up songcompare build artifacts..."
+rm -rf songcompare
+rm -f hifiberry-songcompare_*
+rm -f hifiberry-songcompare-*
+echo "Cleaned up songcompare build artifacts."


### PR DESCRIPTION
Adds `packages/songcompare/`, building `hifiberry-songcompare` from [github.com/hifiberry/songcompare](https://github.com/hifiberry/songcompare).

songcompare is the A/B listening-comparison tool used for evaluating masters, codecs and filter changes: it level-matches two or more renderings of the same recording, optionally aligns them by cross-correlation, and crossfades the switch so only the difference under test is audible. It was published but never packaged, so getting it onto a machine meant a Rust toolchain and `cargo install`.

**Depends on hifiberry/songcompare#2**, which adds the `debian/` directory this wrapper builds. Merge that first; until it lands, `build.sh` here clones a tree with no packaging in it.

## Shape

The wrapper follows analog-recognition: clone upstream, build with sbuild, keep the `.deb` and prune the rest. The packaging lives upstream, as it does for every other HiFiBerry-owned repository, so there is no `debian/` overlay here to drift from the source it describes. Network stays enabled during the build because cargo fetches the crate dependencies.

Deliberately in no `hbos-*` meta-package. It is an interactive tool run by hand on a listening-test machine, not a service, so it is published to the apt repository and installed on demand.

The clone target is gitignored and listed in `repos.md`, which `scripts/check-packages.py` verifies. `packages/build-all` picks the directory up on its own.

## Verification

Built in the container route (`debian:trixie`, arm64 sbuild chroot), which is the only supported route on this machine:

- `hifiberry-songcompare_1.0.1_arm64.deb`, one binary at `/usr/bin/songcompare`, depending on `libasound2t64 (>= 1.0.29), libc6 (>= 2.39), libgcc-s1 (>= 4.2)`
- 22 unit tests ran and passed inside the chroot
- `scripts/check-packages.py` clean, including the version consistency check with the sources checked out
- `clean.sh` removes the checkout and the `.deb`, leaving the directory as committed

Two failures found and fixed upstream on the way: a missing `ca-certificates` build dependency, without which cargo could not reach index.crates.io, and a `let` chain that trixie's rustc 1.85.0 rejects. Both are in hifiberry/songcompare#2.