### PR TITLE
fix(upgrade): upgrade hifiberry-bluetooth before any apt upgrade step

### DIFF
--- a/scripts/upgrade-bookworm-to-trixie
+++ b/scripts/upgrade-bookworm-to-trixie
@@ -112,13 +112,49 @@ update_sources_list() {
     log_success "APT sources updated for Trixie"
 }
 
+# hifiberry-audiocontrol declares Breaks: hifiberry-bluetooth (<< 1.0.6), so
+# unpacking a newer audiocontrol over an older bluetooth makes dpkg deconfigure
+# bluetooth first. Every hifiberry-bluetooth up to 1.0.8 ships a prerm that
+# rejects the deconfigure argument and exits 1, which aborts the transaction
+# mid-unpack and leaves the system full of unpacked but unconfigured packages.
+# dpkg runs the prerm of the *installed* version, so the archive cannot fix
+# this for devices already below 1.0.6 -- upgrading the package on its own
+# first is what stops dpkg ever having to deconfigure it. This has to happen
+# before any apt upgrade step, not just before the full upgrade: a plain
+# "apt upgrade" resolves Breaks by deconfiguring too.
+preupgrade_hifiberry_bluetooth() {
+    local status version
+    status=$(dpkg-query -W -f='${Status}' hifiberry-bluetooth 2>/dev/null) || return 0
+    case "$status" in
+        *" ok installed") ;;
+        *) return 0 ;;
+    esac
+
+    log_info "Upgrading hifiberry-bluetooth ahead of the other packages..."
+    if ! apt install -y --only-upgrade hifiberry-bluetooth; then
+        log_warning "Pre-upgrade of hifiberry-bluetooth failed; repairing dpkg state"
+        dpkg --configure -a || true
+    fi
+
+    version=$(dpkg-query -W -f='${Version}' hifiberry-bluetooth 2>/dev/null || true)
+    if [ -z "$version" ] || ! dpkg --compare-versions "$version" ge 1.0.6; then
+        log_warning "hifiberry-bluetooth is ${version:-unknown}, still below 1.0.6 --"
+        log_warning "the upgrade may abort while dpkg deconfigures it."
+    fi
+}
+
 # Function to perform the upgrade
 perform_upgrade() {
     log_info "Starting upgrade process..."
+
+    # Applies to every apt step below, the pre-upgrade included.
+    export DEBIAN_FRONTEND=noninteractive
     
     # Update package lists
     log_info "Updating package lists..."
     apt update
+    
+    preupgrade_hifiberry_bluetooth
     
     # Upgrade APT and dpkg first
     log_info "Upgrading package management tools..."
@@ -131,9 +167,6 @@ perform_upgrade() {
     # Full distribution upgrade
     log_info "Performing full distribution upgrade..."
     log_warning "This may take a long time and require user interaction..."
-    
-    # Use DEBIAN_FRONTEND=noninteractive for automated upgrades where possible
-    export DEBIAN_FRONTEND=noninteractive
     
     # Perform the distribution upgrade
     apt full-upgrade -y

--- a/upgrade-to-trixie
+++ b/upgrade-to-trixie
@@ -54,6 +54,37 @@ fi
 
 echo "Starting upgrade to Debian 13 (Trixie)..."
 
+# hifiberry-audiocontrol declares Breaks: hifiberry-bluetooth (<< 1.0.6), so
+# unpacking a newer audiocontrol over an older bluetooth makes dpkg deconfigure
+# bluetooth first. Every hifiberry-bluetooth up to 1.0.8 ships a prerm that
+# rejects the deconfigure argument and exits 1, which aborts the transaction
+# mid-unpack and leaves the system full of unpacked but unconfigured packages.
+# dpkg runs the prerm of the *installed* version, so the archive cannot fix
+# this for devices already below 1.0.6 -- upgrading the package on its own
+# first is what stops dpkg ever having to deconfigure it. This has to happen
+# before any apt upgrade step, not just before the full upgrade: a plain
+# "apt upgrade" resolves Breaks by deconfiguring too.
+preupgrade_hifiberry_bluetooth() {
+    local status version
+    status=$(dpkg-query -W -f='${Status}' hifiberry-bluetooth 2>/dev/null) || return 0
+    case "$status" in
+        *" ok installed") ;;
+        *) return 0 ;;
+    esac
+
+    echo "Upgrading hifiberry-bluetooth ahead of the other packages..."
+    if ! sudo apt install -y --only-upgrade hifiberry-bluetooth; then
+        echo WARNING: "Pre-upgrade of hifiberry-bluetooth failed; repairing dpkg state"
+        sudo dpkg --configure -a || true
+    fi
+
+    version=$(dpkg-query -W -f='${Version}' hifiberry-bluetooth 2>/dev/null || true)
+    if [ -z "$version" ] || ! dpkg --compare-versions "$version" ge 1.0.6; then
+        echo WARNING: "hifiberry-bluetooth is ${version:-unknown}, still below 1.0.6 --"
+        echo WARNING: "the upgrade may abort while dpkg deconfigures it."
+    fi
+}
+
 # Backup sources.list
 echo "Backing up current package sources..."
 sudo cp /etc/apt/sources.list /etc/apt/sources.list.backup.$(date +%Y%m%d_%H%M%S)
@@ -71,6 +102,8 @@ if ! sudo apt update; then
     sudo cp /etc/apt/sources.list.backup.* /etc/apt/sources.list 2>/dev/null || true
     exit 1
 fi
+
+preupgrade_hifiberry_bluetooth
 
 # Perform minimal upgrade first
 echo "Performing minimal upgrade..."


### PR DESCRIPTION
Follow-up to hbos-bluetooth#4, which fixed the `prerm` at source. This closes the window for devices that are **already** below the affected version, where the archive cannot help them.

### The failure

`hifiberry-audiocontrol` declares `Breaks: hifiberry-bluetooth (<< 1.0.6)`, so unpacking a newer audiocontrol over an older bluetooth makes dpkg deconfigure bluetooth first. Every released `hifiberry-bluetooth` up to 1.0.8 ships a `prerm` that rejects the `deconfigure` argument and exits 1:

    De-configuring hifiberry-bluetooth (1.0.2), to allow installation of
    hifiberry-audiocontrol (0.18.0) ...
    prerm called with unknown argument `deconfigure'

That aborts the whole transaction during unpack. Seen on a device upgrading 458 packages: 456 left unpacked but unconfigured — glibc, systemd and the kernel among them — and `raspberrypi-sys-mods` caught with its `/etc/sudoers.d/010_pi-nopasswd` moved aside and not yet replaced, so `sudo` demanded a password that recovery did not have. Recovering it needed `dpkg --configure -a` plus a hand-patched `prerm`.

dpkg runs the `prerm` of the **installed** version, so 1.0.9 does not protect a device sitting at 1.0.2. Upgrading the package on its own first means dpkg never has to deconfigure it.

### Placement matters

The pre-upgrade runs immediately after `apt update`, **before** the minimal `apt upgrade` — not merely before the full upgrade. A plain `apt upgrade` resolves `Breaks` by deconfiguring too (it only holds back changes needing *removals*, and this is not one), and in `upgrade-to-trixie` that minimal upgrade runs before the reboot, so a guard placed at the full-upgrade step would never have run in time.

### Behaviour

- Treats a held package as installed — `hold ok installed` is just as exposed as `install ok installed`.
- If its own apt run fails, runs `dpkg --configure -a` rather than walking into the full upgrade with dpkg interrupted.
- Warns loudly if the version is still below 1.0.6 afterwards, so a device that cannot reach it says so before the destructive step instead of failing silently.
- No-op, silently, when the package is not installed.
- In `upgrade-bookworm-to-trixie`, `DEBIAN_FRONTEND=noninteractive` moves to the top of `perform_upgrade` so it covers every apt call including this one.

### Deliberately not changed

audiocontrol's `Breaks` stays as is. Deconfiguring on `Breaks` is correct dpkg behaviour under Policy 7.4 — the defect was the `prerm`. The relation prevents audiocontrol merging `players.d/bluetooth.json` against the legacy inline entry into two `BluetoothPlayerController`s on the same BlueZ interface, and an audit of the six player packages it breaks against found bluetooth to be the only one with the gap: `librespot`, `shairport`, `squeezelite` and `raat` have no argument dispatch in their prerm, and `mpd` already handles `deconfigure`.

### Testing

The function was exercised against real `dpkg-query`/`dpkg --compare-versions` on a device with `apt` stubbed: installed-and-current (no warning), apt failure (repair path plus warning), not-installed (silent early return), and the 1.0.2/1.0.5/1.0.6/1.0.9 version-compare boundary. Both scripts pass `bash -n`.

### Known remaining gap

A device already on Trixie below 1.0.6 that runs `apt install hbos-minimal` directly (`install-all`) hits the same abort; this change only covers the Bookworm→Trixie scripts.