### PR TITLE
Add WebUI option to disable Spotify volume control

### DIFF
--- a/packages/librespot/src/debian/changelog
+++ b/packages/librespot/src/debian/changelog
@@ -1,3 +1,13 @@
+hifiberry-librespot (0.8.0.11) stable; urgency=medium
+
+  * Add a WebUI Players setting to disable Spotify volume control. When
+    allow_volume_control is off, start-librespot skips the ALSA mixer and
+    runs with softvol, so Spotify Connect cannot slam hardware gain.
+    Default remains on (stock behaviour). Takes effect after restarting
+    the librespot service.
+
+ -- HiFiBerry <support@hifiberry.com>  Sat, 06 Sep 2026 09:00:00 +0000
+
 hifiberry-librespot (0.8.0.10) stable; urgency=medium
 
   * Ship the WebUI player descriptor and icon from

--- a/packages/librespot/src/debian/start-librespot.1
+++ b/packages/librespot/src/debian/start-librespot.1
@@ -1,4 +1,4 @@
-.TH START-LIBRESPOT 1 "2025-01-27" "HiFiBerry" "User Commands"
+.TH START-LIBRESPOT 1 "2026-09-06" "HiFiBerry" "User Commands"
 .SH NAME
 start-librespot \- Librespot startup script for HiFiBerry devices
 .SH SYNOPSIS
@@ -9,9 +9,17 @@ is a startup script that handles the initialization of librespot with system-spe
 configuration for HiFiBerry devices. It automatically configures audio parameters
 based on the detected sound card and uses the system's pretty hostname.
 .PP
-The script sets up librespot with a default bitrate of 320 kbps and uses the ALSA
-audio backend. It attempts to get the system's pretty hostname, falling back to
+The script sets up librespot with a default bitrate of 320 kbps and the rodio
+backend. It attempts to get the system's pretty hostname, falling back to
 the regular hostname, and finally to "HiFiBerry" if neither is available.
+.PP
+By default it attaches librespot to the card's ALSA mixer so Spotify Connect
+can change the system volume. That can be disabled from the WebUI under
+Services > Players > Spotify ("Allow Spotify volume control"), which stores
+.I player.librespot.allow_volume_control
+in ConfigDB. When disabled, librespot uses software volume fixed at 100%
+instead, so only the HiFiBerry volume control moves the output level.
+Changing the setting takes effect after this player is restarted.
 .SH ENVIRONMENT
 .TP
 .B VOLUME_CTRL
@@ -22,6 +30,21 @@ Defaults to
 (unchanged behaviour). Set it via a systemd drop-in, e.g.
 .I Environment=VOLUME_CTRL=cubic ,
 for a more naturally curved Spotify Connect volume slider.
+When Spotify volume control is disabled (see
+.BR ALLOW_VOLUME_CONTROL ),
+this is forced to
+.IR fixed .
+.TP
+.B ALLOW_VOLUME_CONTROL
+When
+.IR false ,
+skip ALSA mixer attachment and run with
+.B --mixer softvol
+.B --volume-ctrl fixed
+.BR --initial-volume " 100."
+When unset, the value is read from ConfigDB key
+.IR player.librespot.allow_volume_control
+(default true if unset or config-server is unreachable).
 .SH FILES
 .I /etc/hostname
 .RS

--- a/packages/librespot/src/start-librespot.sh
+++ b/packages/librespot/src/start-librespot.sh
@@ -4,8 +4,12 @@
 # This script handles startup of librespot with the system's pretty hostname
 # and auto-configures audio parameters based on the detected sound card
 #
-# Version: 1.1.2
+# Version: 1.2.0
 # Changelog:
+# - v1.2.0: Honour player.librespot.allow_volume_control from ConfigDB (WebUI
+#           Players > Spotify setting). When false, skip ALSA mixer attachment and
+#           use softvol + fixed volume so Spotify cannot drive hardware gain.
+#           Optional ALLOW_VOLUME_CONTROL env override for debugging/drop-ins.
 # - v1.1.2: Added VOLUME_CTRL environment knob to select librespot's volume curve
 #           (linear|log|cubic|fixed). Default remains "linear" (unchanged behaviour);
 #           integrators can override via a systemd drop-in (Environment=VOLUME_CTRL=cubic).
@@ -50,6 +54,21 @@ BACKEND="rodio"
 #   [Service]
 #   Environment=VOLUME_CTRL=cubic
 VOLUME_CTRL="${VOLUME_CTRL:-linear}"
+
+# Whether Spotify Connect may drive the ALSA/system mixer (true/false).
+# Default true keeps stock behaviour. WebUI stores
+# player.librespot.allow_volume_control in ConfigDB; override with a drop-in:
+#   Environment=ALLOW_VOLUME_CONTROL=false
+if [ -z "${ALLOW_VOLUME_CONTROL:-}" ]; then
+  response=$(curl -sf --max-time 2 "http://localhost:1081/api/v1/key/player.librespot.allow_volume_control" 2>/dev/null) || response=""
+  value=$(echo "$response" | sed -n 's/.*"value"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  # Unset key or unreachable config-server defaults to true (previous stock behaviour)
+  ALLOW_VOLUME_CONTROL="${value:-true}"
+fi
+if [ "$ALLOW_VOLUME_CONTROL" = "false" ]; then
+  # Softvol at 100% so Connect cannot change level (see --mixer softvol below)
+  VOLUME_CTRL="fixed"
+fi
 
 # MDNS backend
 ZEROCONF_BACKEND="avahi"
@@ -118,11 +137,17 @@ else
   echo "No access token available on audiocontrol"
 fi
 
-# Try to get both mixer name and hardware index from configurator
-if command -v config-soundcard >/dev/null 2>&1; then
+# Mixer: ALSA when Spotify volume control is allowed, otherwise softvol fixed
+# at 100% so Connect cannot move the hardware/system volume.
+if [ "$ALLOW_VOLUME_CONTROL" = "false" ]; then
+  echo "Spotify volume control disabled; using softvol with fixed volume"
+  LIBRESPOT_OPTS+=("--mixer" "softvol")
+  LIBRESPOT_OPTS+=("--initial-volume" "100")
+elif command -v config-soundcard >/dev/null 2>&1; then
+  # Try to get both mixer name and hardware index from configurator
   MIXER_NAME=$(config-soundcard --no-eeprom --volume-control-softvol 2>/dev/null)
   HW_INDEX=$(config-soundcard --no-eeprom --hw 2>/dev/null)
-  
+
   # Only use all three audio options together if both mixer and hw index are available
   if [ $? -eq 0 ] && [ -n "$MIXER_NAME" ] && [ -n "$HW_INDEX" ]; then
     echo "Using mixer control: $MIXER_NAME and hardware device: hw:$HW_INDEX"

--- a/packages/librespot/src/ui-players.d/librespot.json
+++ b/packages/librespot/src/ui-players.d/librespot.json
@@ -6,5 +6,14 @@
     "allow_change": true,
     "conflicts_with": ["soloist"],
     "maintainer_name": "Wanted",
-    "maintainer_url": "https://github.com/hifiberry/hifiberry-os/blob/hbosng/docs/maintainers-wanted.md"
+    "maintainer_url": "https://github.com/hifiberry/hifiberry-os/blob/hbosng/docs/maintainers-wanted.md",
+    "settings": [
+        {
+            "key": "allow_volume_control",
+            "type": "toggle",
+            "label": "Allow Spotify volume control",
+            "description": "When off, Spotify cannot change the system volume. Use the HiFiBerry volume control instead. Takes effect after this player is restarted.",
+            "default": true
+        }
+    ]
 }


### PR DESCRIPTION
## Summary

Spotify Connect currently drives the ALSA/system mixer by default. That can be convenient for phone-volume control, but it can also unexpectedly slam hardware gain (or fight the HiFiBerry volume control) when Spotify Connect connects (usually sets to 94% for me).

Users have run into this before: in #586 someone already disabled vollibrespot volume control so playback followed global volume only. #590 and #8 also show the same class of surprises.

This adds a Players > Spotify toggle, **Allow Spotify volume control** (default **on**, stock behaviour unchanged):

- Stored as `player.librespot.allow_volume_control` in ConfigDB
- When off, `start-librespot` skips the ALSA mixer and runs `--mixer softvol --volume-ctrl fixed --initial-volume 100`. (This still seems to allow the Spotify client to set librespot volume lower, though, seems to be a bug upstream: https://github.com/librespot-org/librespot/pull/1642).
- Optional `ALLOW_VOLUME_CONTROL` env override for drop-ins/debugging
- Takes effect after player is restarted

## Manual tests done
- [✓] Toggle appears under Services > Players > Spotify (default on)
- [✓] Default on: restart player → ALSA mixer still attached; Connect volume moves system level
- [✓] Toggle off + restart player → log shows softvol/fixed; Connect no longer moves system/ALSA volume; HiFiBerry volume still works
- [✓] Toggle on again + restart → previous behaviour restored
- [✓] `curl -s http://localhost:1081/api/v1/key/player.librespot.allow_volume_control` reflects the setting