### PR TITLE
docs(api): document the speaker preset endpoints

### DIFF
--- a/docs/backend-apis.md
+++ b/docs/backend-apis.md
@@ -144,6 +144,37 @@ Backend: Python (Flask + Waitress), port 13141. Runs as system service via `sigm
 ### Biquad
 - `POST /api/dsptoolkit/biquad` — Calculate biquad coefficients
 
+### Speaker Presets
+- `GET /api/dsptoolkit/presets` — List installed speaker presets. Each entry
+  carries `compatible`/`incompatibleReason` (`null` when compatible),
+  evaluated server-side against the loaded DSP profile, plus a top-level
+  `current` — the preset applied to that profile, or `null` if none is. `ok`
+  tier.
+- `GET /api/dsptoolkit/presets/<id>` — One preset in full. 404 if no file with
+  that id exists in either preset directory; 500 (carrying the reason) if a
+  file exists but fails validation, so a hand-edited preset with a typo
+  reports what's wrong with it instead of silently vanishing from the list.
+  `ok` tier.
+- `POST /api/dsptoolkit/presets/<id>/apply` — Apply the preset: four biquad
+  banks and sixteen per-channel registers, written under one lock and
+  recorded in the settings store so they survive a reboot and a profile
+  reload. Every compatibility check — including whether the loaded profile
+  can express each channel's role — runs before the first write, so an
+  incompatible preset answers 409 and writes nothing. If the active profile's
+  checksum can't be read, the request is refused with 503 rather than writing
+  changes that couldn't be recorded and would vanish at the next profile
+  load. A failure partway through answers 500 and reports how many
+  `banksWritten`/`filtersWritten`/`registersWritten` before it failed. `risky`
+  tier — requires authentication.
+
+Presets are read from `/usr/share/hifiberry/speaker-presets` (shipped by
+`hifiberry-dspprofiles`) and `/var/lib/hifiberry/speaker-presets` (local,
+shadowing a shipped preset of the same id). Applying one is refused unless the
+loaded profile matches the preset's required DSP program, at least its
+minimum version, and its sample rate: preset coefficients are computed for
+one sample rate and cannot be rescaled, so applying 48 kHz biquads to a
+96 kHz program would produce a plausible-looking, wrong crossover.
+
 ## PipeWire API (`/api/pipewire/`)
 
 Backend: C/Rust, port 2716. Runs as user service via `pipewire-api.service`.

--- a/docs/backend-apis.md
+++ b/docs/backend-apis.md
@@ -156,7 +156,7 @@ Backend: Python (Flask + Waitress), port 13141. Runs as system service via `sigm
   reports what's wrong with it instead of silently vanishing from the list.
   `ok` tier.
 - `POST /api/dsptoolkit/presets/<id>/apply` — Apply the preset: four biquad
-  banks and sixteen per-channel registers, written under one lock and
+  banks and up to sixteen per-channel registers, written under one lock and
   recorded in the settings store so they survive a reboot and a profile
   reload. Every compatibility check — including whether the loaded profile
   can express each channel's role — runs before the first write, so an
@@ -171,9 +171,10 @@ Presets are read from `/usr/share/hifiberry/speaker-presets` (shipped by
 `hifiberry-dspprofiles`) and `/var/lib/hifiberry/speaker-presets` (local,
 shadowing a shipped preset of the same id). Applying one is refused unless the
 loaded profile matches the preset's required DSP program, at least its
-minimum version, and its sample rate: preset coefficients are computed for
-one sample rate and cannot be rescaled, so applying 48 kHz biquads to a
-96 kHz program would produce a plausible-looking, wrong crossover.
+minimum version, and its sample rate, with filter banks large enough for the
+preset's filters: preset coefficients are computed for one sample rate and
+cannot be rescaled, so applying 48 kHz biquads to a 96 kHz program would
+produce a plausible-looking, wrong crossover.
 
 ## PipeWire API (`/api/pipewire/`)
 

--- a/docs/backend-apis.md
+++ b/docs/backend-apis.md
@@ -166,6 +166,13 @@ Backend: Python (Flask + Waitress), port 13141. Runs as system service via `sigm
   load. A failure partway through answers 500 and reports how many
   `banksWritten`/`filtersWritten`/`registersWritten` before it failed. `risky`
   tier — requires authentication.
+- `DELETE /api/dsptoolkit/presets/current` — Clear the applied preset:
+  writes a transparent biquad into every slot of all four banks and clears
+  their bypass state, then forgets the recorded selection. The per-channel
+  role/level/delay/polarity registers are deliberately left alone — clearing
+  filters is not the same as re-routing the amplifier. Clearing when nothing
+  is applied answers 200 with `cleared: null`; an unreadable profile checksum
+  is a 503, same as apply. `risky` tier — requires authentication.
 
 Presets are read from `/usr/share/hifiberry/speaker-presets` (shipped by
 `hifiberry-dspprofiles`) and `/var/lib/hifiberry/speaker-presets` (local,


### PR DESCRIPTION
Documents the four speaker preset endpoints in `docs/backend-apis.md`, alongside the rest of the DSP toolkit API.

- `GET /api/dsptoolkit/presets` and `GET /api/dsptoolkit/presets/<id>` — `ok` tier
- `POST /api/dsptoolkit/presets/<id>/apply` and `DELETE /api/dsptoolkit/presets/current` — `risky` tier

Beyond the request shapes, the entries record the behaviour a client has to plan for: the 409 when a preset is incompatible and the guarantee that nothing was written, the 503 when the profile checksum cannot be read, the `banksWritten`/`filtersWritten`/`registersWritten` counts a partial failure reports, and the deliberate decision that clearing a preset does not touch the per-channel role, level, delay and polarity registers.

Also notes the two preset directories and their shadowing order, and why the sample rate is a hard gate: preset coefficients are computed for one rate and cannot be rescaled, so applying 48 kHz biquads to a 96 kHz program would produce a plausible-looking, wrong crossover.

Documentation only — the implementation is in `hifiberry-dsp`, the presets in `dspprofiles` and the page in `hbos-ui`.