### PR TITLE
fix(squeezelite): stop shadowing the packaged descriptor with an /etc copy

### DIFF
--- a/packages/squeezelite/src/debian/changelog
+++ b/packages/squeezelite/src/debian/changelog
@@ -1,3 +1,20 @@
+hifiberry-squeezelite (2.0.0.1566) stable; urgency=medium
+
+  * postinst: stop writing the WebUI descriptor and icon into
+    /etc/hifiberry/players.d. 2.0.0.1565 moved both to
+    /usr/share/hifiberry/players.d, but left this postinst overwriting them on
+    every configure, and configurator lets /etc shadow /usr/share -- so the
+    packaged descriptor has been masked ever since and nothing has read it.
+    The two are byte-identical today, so nothing is visibly broken; that is
+    the reason to fix it now rather than after a field is added. The same
+    omission cost hifiberry-librespot a conflicts_with declaration and
+    hifiberry-shairport its entire settings block, both silently.
+  * postinst: remove the stale /etc copy when upgrading from an affected
+    version. A file present on a fresh install is left alone: there it is an
+    administrator's own override.
+
+ -- HiFiBerry <support@hifiberry.com>  Mon, 07 Sep 2026 10:26:48 +0000
+
 hifiberry-squeezelite (2.0.0.1565) stable; urgency=medium
 
   * Ship the WebUI player descriptor and icon from

--- a/packages/squeezelite/src/debian/postinst
+++ b/packages/squeezelite/src/debian/postinst
@@ -18,28 +18,27 @@ case "$1" in
             chown squeezelite:squeezelite /var/lib/squeezelite
         fi
 
-        # Register in Web UI player registry
-        HBOS_PLAYERS_D="/etc/hifiberry/players.d"
-        mkdir -p "$HBOS_PLAYERS_D/icons"
-
-        cat > "$HBOS_PLAYERS_D/squeezelite.json" <<'PLAYEREOF'
-{
-    "name": "LMS",
-    "provided_by": "squeezelite",
-    "systemd_service": "squeezelite",
-    "icon": "squeezelite",
-    "allow_change": true,
-    "maintainer_name": "Wanted",
-    "maintainer_url": "https://github.com/hifiberry/hifiberry-os/blob/hbosng/docs/maintainers-wanted.md"
-}
-PLAYEREOF
-
-        # Install icon
-        if [ -f /usr/share/hifiberry-squeezelite/icons/squeezelite.svg ]; then
-            cp /usr/share/hifiberry-squeezelite/icons/squeezelite.svg "$HBOS_PLAYERS_D/icons/squeezelite.svg"
+        # Up to 2.0.0.1565 this postinst wrote the WebUI descriptor and its icon
+        # into /etc/hifiberry/players.d. 2.0.0.1565 moved both to
+        # /usr/share/hifiberry/players.d, and configurator lets /etc shadow
+        # /usr/share -- so the copy written here masked the packaged one and
+        # nothing ever read it. The move changed where the files ship; it did
+        # not stop this postinst overwriting them.
+        #
+        # The two copies are identical today, so nothing is visibly broken.
+        # That is the reason to fix it now: the next field added to the shipped
+        # descriptor would be masked silently, which is how hifiberry-librespot
+        # lost a conflicts_with declaration and hifiberry-shairport lost its
+        # entire settings block.
+        #
+        # Remove the stale copy, but only when upgrading from an affected
+        # version. On a fresh install a file here is an administrator's own
+        # override, which is what /etc is for.
+        if [ -n "$2" ] && dpkg --compare-versions "$2" lt 2.0.0.1566; then
+            rm -f /etc/hifiberry/players.d/squeezelite.json
+            rm -f /etc/hifiberry/players.d/icons/squeezelite.svg
+            echo "Removed the /etc descriptor that shadowed the packaged one."
         fi
-
-        echo "Registered LMS/squeezelite in Web UI player registry."
 
         # Register systemd permissions via configserver drop-in
         mkdir -p /etc/configserver/conf.d


### PR DESCRIPTION
`2.0.0.1565` moved the WebUI descriptor and icon to `/usr/share/hifiberry/players.d` because a descriptor is package data, not configuration. It did not touch the `postinst`, which kept writing `/etc/hifiberry/players.d/squeezelite.json` on every configure. configurator lets `/etc` shadow `/usr/share`, so the file the package ships has been masked since that release and nothing has read it.

## Why fix it while nothing looks broken

The two copies are still byte-identical, so there is no visible symptom. That is precisely why it is worth fixing now — the failure only appears when the shipped descriptor gains a field, and then it appears silently. Two sibling packages have already been through exactly that:

- **hifiberry-librespot** gained `conflicts_with: ["soloist"]`; its shadow did not, leaving the librespot/soloist conflict declared on one side only.
- **hifiberry-shairport** gained the whole `airplay_version` settings block, so the AirPlay 1/2 selector sat in the `.deb` and was invisible in the web interface.

Neither produced an error anywhere. Both were found only by diffing the two copies on a running device.

## The change

- Drop the descriptor and icon writes from `postinst`.
- Clear the stale `/etc` copy when upgrading from an affected version, guarded on `$2` so a descriptor found on a *fresh* install — where it can only be an administrator's own override — is left alone.

Verified on a device that both descriptor and icon are shipped under `/usr/share` and dpkg-owned (`hifiberry-squeezelite: /usr/share/hifiberry/players.d/squeezelite.json` and `…/icons/squeezelite.svg`), so the removal falls through to the packaged files rather than leaving the player without an icon.

`bash -n` passes, `dpkg-parsechangelog` reads the new entry as `2.0.0.1566`, and `scripts/check-packages.py --skip-versions` reports `ok - 0 warning(s)`.

Completes the family: hifiberry/hifiberry-librespot#2 (merged, published), hifiberry/hifiberry-shairport#2 (merged), hifiberry/analog-recognition#3.