### PR TITLE
Ignore credential files in the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,8 @@ __pycache__/
 
 # Isolated worktrees for the nested package repos (SDD workspaces)
 .worktrees/
+
+# Credentials, so that an untracked token dropped in the working tree is
+# never one `git add -A` away from being committed.
+.controltower-token
+*.token


### PR DESCRIPTION
The repository root was covered by no credential pattern, so a token file dropped in the working tree would be staged by `git add -A` without complaint.

Adds `.controltower-token` and the general `*.token`.

No such file has ever been committed here — this closes the gap rather than cleaning up after it. Verified by creating both `.controltower-token` and `x.token` in the working tree and confirming `git status` no longer offers them.