### PR TITLE
Document what --clean removes, and two builds that succeed without building

### DIFF
--- a/packages/build.md
+++ b/packages/build.md
@@ -247,7 +247,12 @@ cd packages
 
 Options:
 
-- `--clean` — remove existing `.deb` files first and rebuild
+- `--clean` — **removes the source checkout, not just the `.deb` files.** It
+  runs each package's `clean.sh`, and those start with a line like
+  `rm -rf configurator` or `rm -rf $BASE` that deletes the cloned source
+  directory. If that checkout holds work you have not pushed, `--clean`
+  destroys it. To force a rebuild without that risk, delete the stale `.deb`
+  files by hand (see below).
 - `--rebuild-image` — force a rebuild of the builder image
 - `--shell` — open a shell inside the build container
 - `--stop` — stop and remove the build container
@@ -255,6 +260,48 @@ Options:
 The first run is slow: it builds the `hifiberryos-builder` image and then
 creates the sbuild chroot inside it. The chroot lives in a named volume, so
 later runs reuse it and start compiling immediately.
+
+### When a build reports success without building
+
+`docker-build.sh` exits 0 and prints `Succeeded` in two cases where nothing was
+actually rebuilt. Both are easy to act on and hard to notice.
+
+**A package that already has a `.deb` is skipped.** The summary reads
+`Succeeded: <pkg> (cached)`. If you have just changed the source, that line
+means your change is *not* in the artefact. Remove the stale file first:
+
+```sh
+rm -f packages/<pkg>/*.deb
+```
+
+**hbos-ui reuses an existing `dist/`.** The inner `build.sh` prints
+`Using existing dist/ (set FORCE_VUE_BUILD=1 to rebuild)` and then
+`Vue.js build completed successfully`, so a stale bundle is packaged and the
+build still reports success. `FORCE_VUE_BUILD=1` cannot be passed through
+`docker-build.sh`, which invokes the build with `docker exec` and no
+environment, so the way to force it is to remove the directory:
+
+```sh
+rm -rf packages/webui/hbos-ui/dist
+```
+
+Note also that the container has neither npm nor Docker, so it cannot build the
+Vue application itself: it can only package a `dist/` that already exists.
+Build that on the host first (`npx vite build --config vite.config.ts` in
+`packages/webui/hbos-ui`), then run the container build to produce the `.deb`.
+Building it on the host also deletes `node_modules` as a side effect of
+packaging, so expect to re-run `npm ci` afterwards.
+
+**Check the artefact, not the exit code.** The reliable test is to look inside
+the built package for something that must be there:
+
+```sh
+cd /tmp && ar x /path/to/pkg.deb && tar tf data.tar.* | grep <expected-file>
+```
+
+That is what distinguishes a real build from a cached one, and it is worth
+doing before shipping a `.deb` to a device or the repository.
+
 
 ### Architecture
 


### PR DESCRIPTION
Three things found while building and publishing packages, each of which cost real time and none of which were written down.

The first is a correction, not an addition. The clean option was documented as removing existing package files first. It does not. It runs each package's clean script, and those open with a recursive delete of the source checkout itself, not of build output. Reaching for it as the obvious way to force a rebuild deletes a clone and any unpushed commits in it. That nearly happened here, with eleven unpushed commits in the checkout at the time.

The other two are cases where the container build exits zero and prints Succeeded while rebuilding nothing.

It skips any package that already has a built artefact, reporting it as cached. If the source has just changed, that line means the change is not in the artefact.

The web UI build reuses an existing dist directory and still reports a successful build. This shipped a package containing a UI compiled before the feature it was supposed to carry, and the only reason it was caught was extracting the package and grepping for a string that had to be there. The environment variable that forces a rebuild cannot be passed through the container script, which invokes the build without an environment, so removing the directory is the way to force it.

Also recorded: the build container has neither npm nor a nested container runtime, so it cannot build the Vue application at all, only package a dist that already exists. Building that on the host is a prerequisite, and packaging then deletes the installed node modules as a side effect, so a reinstall is expected afterwards.

The practical conclusion is in there too: check the artefact rather than the exit code. Extracting the package and looking for a file that must be present is what distinguishes a real build from a cached one, and it is worth doing before a package reaches a device or the repository.